### PR TITLE
[JRO] Handle correctly when no email body is provided

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     griddler (0.2.0)
+      htmlentities
       rails (>= 3.2.0)
 
 GEM
@@ -39,6 +40,7 @@ GEM
     diff-lcs (1.1.3)
     erubis (2.7.0)
     hike (1.2.1)
+    htmlentities (4.3.1)
     i18n (0.6.1)
     journey (1.0.4)
     jquery-rails (2.1.3)
@@ -94,7 +96,7 @@ GEM
       hike (~> 1.2)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sqlite3 (1.3.6)
+    sqlite3 (1.3.7)
     thor (0.16.0)
     tilt (1.3.3)
     treetop (1.4.12)

--- a/griddler.gemspec
+++ b/griddler.gemspec
@@ -15,8 +15,9 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,lib}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
 
   s.add_dependency 'rails', '>= 3.2.0'
+  s.add_dependency 'htmlentities'
   s.require_paths = %w{app lib}
 
-  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails'
+  s.add_development_dependency 'sqlite3'
 end

--- a/lib/griddler.rb
+++ b/lib/griddler.rb
@@ -1,3 +1,4 @@
+require 'griddler/errors'
 require 'griddler/engine'
 require 'griddler/email'
 require 'griddler/email_format'

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -26,9 +26,9 @@ module EmailParser
       body.split(delimeter).first.
         split(/^\s*[-]+\s*Original Message\s*[-]+\s*$/).first.
         split(/^\s*--\s*$/).first.
+        gsub(/On.*wrote:/, '').
         split(/[\r]*\n/).reject do |line|
           line =~ /^\s*>/ ||
-            line =~ /^\s*On.*wrote:$/ ||
             line =~ /^\s*Sent from my /
         end.
         join("\n").

--- a/lib/griddler/errors.rb
+++ b/lib/griddler/errors.rb
@@ -1,0 +1,9 @@
+module Griddler
+  class Error < StandardError
+  end
+
+  module Errors
+    class EmailBodyNotFound < Griddler::Error
+    end
+  end
+end


### PR DESCRIPTION
On client project there were several emails hitting the endpoint with no :text in the params -- only html.  

Another issue - the data within :html is one continuous string, with a lot of ugly email client markup. I've decided to sanitize and clean things up in the extraction point, as well as test and ensure single-line email bodies are parsed correctly. They were not before.
- Throw error if no text or html is posted
- Adjust the body parsing to account for emails that are a long string w/line breaks
- Sanitize and strip tags from html body
- Alphabetize gems in gemspec
