### PR TITLE
Remove unused charsets tempvar

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -48,10 +48,8 @@ class Griddler::Email
 
   def extract_body
     body_text = text_or_sanitized_html
-    charsets = params[:charsets]
 
-    if charsets.present?
-      charsets = ActiveSupport::JSON.decode(charsets)
+    if params[:charsets].present?
       body_text = body_text.encode(
         'UTF-8',
         invalid: :replace,


### PR DESCRIPTION
It looks like earlier versions (such as 1320736b) of #extract_body were
using Iconv and needed the charsets, but the latest version was no
longer using the tempvar for anything
