### PR TITLE
[#28] Properly handle empty email body

### DIFF
--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -21,7 +21,9 @@ module EmailParser
   end
 
   def self.extract_reply_body(body)
-    if body
+    if body.blank?
+      ""
+    else
       delimeter = Griddler.configuration.reply_delimiter
       body.split(delimeter).first.
         split(/^\s*[-]+\s*Original Message\s*[-]+\s*$/).first.

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -209,6 +209,10 @@ describe Griddler::Email, 'body formatting' do
     body_from_email(:text, body).should eq body
   end
 
+  it 'handles empty body values' do
+    body_from_email(:text, "").should eq ""
+  end
+
   def body_from_email(format, text, charsets = {})
     if charsets.present?
       text = text.encode(charsets[format])


### PR DESCRIPTION
Emails with no body cause the reply parser to crash.  This should fix #28.
