### PR TITLE
[#33] Parsed headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,12 @@ that responds to:
 * `.subject`
 * `.body`
 * `.raw_body`
+* `.headers`
+* `.raw_headers`
 
 Each of those has some sensible defaults.
 
-`.from`, `.raw_body` and `.subject` will contain the obvious values found in the email, the raw values from those fields.
+`.from`, `.raw_body`, `.raw_headers`, and `.subject` will contain the obvious values found in the email, the raw values from those fields.
 
 `.body` will contain the full contents of the email body **unless** there is a
 line in the email containing the string `-- Reply ABOVE THIS LINE --`. In that
@@ -71,6 +73,10 @@ case `.body` will contain everything before that line.
 `.to` will contain all of the text before the email's "@" character. We've found
 that this is the most often used portion of the email address and consider it to
 be the token we'll key off of for interaction with our application.
+
+`.headers` will contain a hash of header names and values as parsed by
+the Mail gem. Headers will only be parsed if the adapter supports a
+headers option.
 
 Configuration Options
 ---------------------

--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -1,83 +1,96 @@
 require 'htmlentities'
 
-class Griddler::Email
-  include ActionView::Helpers::SanitizeHelper
-  attr_reader :to, :from, :body, :raw_body, :subject, :attachments
+module Griddler
+  class Email
+    include ActionView::Helpers::SanitizeHelper
+    attr_reader :to, :from, :subject, :body, :raw_body,
+      :headers, :raw_headers, :attachments
 
-  def initialize(params)
-    @params = params
-    @to = extract_address(params[:to], config.to)
-    @from = extract_address(params[:from], :email)
-    @subject = params[:subject]
-    @body = extract_body
-    @raw_body = params[:text] || params[:html]
-    @attachments = params[:attachments]
-  end
+    def initialize(params)
+      @params = params
 
-  def process
-    processor_class = config.processor_class
-    processor_class.process(self)
-  end
+      @to = extract_address(params[:to], config.to)
+      @from = extract_address(params[:from], :email)
+      @subject = params[:subject]
 
-  private
+      @body = extract_body
+      @raw_body = params[:text] || params[:html]
 
-  attr_reader :params
+      @headers = extract_headers
+      @raw_headers = params[:headers]
 
-  def config
-    Griddler.configuration
-  end
-
-  def extract_address(address, type)
-    parsed = EmailParser.parse_address(address)
-
-    if type == :hash
-      parsed
-    else
-      parsed[type]
+      @attachments = params[:attachments]
     end
-  end
 
-  def extract_body
-    EmailParser.extract_reply_body(text_or_sanitized_html)
-  end
-
-  def text_or_sanitized_html
-    if params.key? :text
-      clean_text(params[:text])
-    elsif params.key? :html
-      clean_html(params[:html])
-    else
-      raise Griddler::Errors::EmailBodyNotFound
+    def process
+      processor_class = config.processor_class
+      processor_class.process(self)
     end
-  end
 
-  def clean_text(text)
-    clean_invalid_utf8_bytes(text, 'text')
-  end
+    private
 
-  def clean_html(html)
-    cleaned_html = clean_invalid_utf8_bytes(html, 'html')
-    cleaned_html = strip_tags(cleaned_html)
-    cleaned_html = HTMLEntities.new.decode(cleaned_html)
-    cleaned_html
-  end
+    attr_reader :params
 
-  def clean_invalid_utf8_bytes(text, email_part)
-    text.encode(
-      'UTF-8',
-      src_encoding(email_part),
-      invalid: :replace,
-      undef: :replace,
-      replace: ''
-    )
-  end
+    def config
+      Griddler.configuration
+    end
 
-  def src_encoding(email_part)
-    if params[:charsets]
-      charsets = ActiveSupport::JSON.decode(params[:charsets])
-      charsets[email_part]
-    else
-      'binary'
+    def extract_address(address, type)
+      parsed = EmailParser.parse_address(address)
+
+      if type == :hash
+        parsed
+      else
+        parsed[type]
+      end
+    end
+
+    def extract_body
+      EmailParser.extract_reply_body(text_or_sanitized_html)
+    end
+
+    def extract_headers
+      EmailParser.extract_headers(params[:headers])
+    end
+
+    def text_or_sanitized_html
+      if params.key? :text
+        clean_text(params[:text])
+      elsif params.key? :html
+        clean_html(params[:html])
+      else
+        raise Errors::EmailBodyNotFound
+      end
+    end
+
+    def clean_text(text)
+      clean_invalid_utf8_bytes(text, 'text')
+    end
+
+    def clean_html(html)
+      cleaned_html = clean_invalid_utf8_bytes(html, 'html')
+      cleaned_html = strip_tags(cleaned_html)
+      cleaned_html = HTMLEntities.new.decode(cleaned_html)
+      cleaned_html
+    end
+
+    def clean_invalid_utf8_bytes(text, email_part)
+      text.encode(
+        'UTF-8',
+        src_encoding(email_part),
+        invalid: :replace,
+        undef: :replace,
+        replace: ''
+      )
+    end
+
+    def src_encoding(email_part)
+      if params[:charsets]
+        charsets = ActiveSupport::JSON.decode(params[:charsets])
+        charsets[email_part]
+      else
+        'binary'
+      end
     end
   end
 end

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -8,7 +8,9 @@
 #   email: 'somebody@example.com',
 #   full: 'Some Body <somebody@example.com>',
 # }
-module EmailParser
+require 'mail'
+
+module Griddler::EmailParser
   def self.parse_address(full_address)
     email_address = extract_email_address(full_address)
     token, host = split_address(email_address)
@@ -36,6 +38,15 @@ module EmailParser
         join("\n").
         gsub(/^\s*On.*\r?\n?\s*.*\s*wrote:$/,'').
         strip
+    end
+  end
+
+  def self.extract_headers(raw_headers)
+    header_fields = Mail::Header.new(raw_headers).fields
+
+    header_fields.inject({}) do |header_hash, header_field|
+      header_hash[header_field.name.to_s] = header_field.value.to_s
+      header_hash
     end
   end
 

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -233,6 +233,39 @@ describe Griddler::Email, 'body formatting' do
   end
 end
 
+describe Griddler::Email, 'extracting email headers' do
+  it 'extracts header names and values as a hash' do
+    header_name = 'Arbitrary-Header'
+    header_value = 'Arbitrary-Value'
+    header = "#{header_name}: #{header_value}"
+
+    headers = header_from_email(header)
+    headers[header_name].should eq header_value
+  end
+
+  it 'handles no matched headers' do
+    headers = header_from_email('')
+    headers.should eq({})
+  end
+
+  it 'handles nil headers' do
+    headers = header_from_email(nil)
+    headers.should eq({})
+  end
+
+  def header_from_email(header)
+    params = {
+      headers: header,
+      to: 'hi@example.com',
+      from: 'bye@example.com',
+      text: ''
+    }
+
+    email = Griddler::Email.new(params).process
+    email.headers
+  end
+end
+
 describe Griddler::Email, 'extracting email addresses' do
   before do
     @address = 'bob@example.com'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,8 +3,6 @@ require File.expand_path("../dummy/config/environment", __FILE__)
 require 'rspec/rails'
 require 'rspec/autorun'
 
-Dir[Rails.root.join("spec/support/**/*.rb")].each {|f| require f}
-
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_base_class_for_anonymous_controllers = false


### PR DESCRIPTION
Adds default headers Regexps and support for configuration to add more header
extracting Regexps. Updated documentation and test coverage. Allows
EmailParser to be injected through configuration similar to
EmailProcessor. Includes an example of this using the Mail gem.

Let me know what you think! Thanks.
