### PR TITLE
Use a fresh hash to weed out the original cloudmailin params

### DIFF
--- a/lib/griddler/adapters/cloudmailin_adapter.rb
+++ b/lib/griddler/adapters/cloudmailin_adapter.rb
@@ -3,6 +3,7 @@ module Griddler
     class CloudmailinAdapter
       def initialize(params)
         @params = params
+        @normalized_params = {}
       end
 
       def self.normalize_params(params)
@@ -11,17 +12,17 @@ module Griddler
       end
 
       def normalize_params
-        params[:to] = params[:envelope][:to]
-        params[:from] = params[:envelope][:from]
-        params[:subject] = params[:headers][:Subject]
-        params[:text] = params[:plain]
-        params[:attachments] ||= []
-        params
+        normalized_params[:to] = params[:envelope][:to]
+        normalized_params[:from] = params[:envelope][:from]
+        normalized_params[:subject] = params[:headers][:Subject]
+        normalized_params[:text] = params[:plain]
+        normalized_params[:attachments] = params[:attachments] || []
+        normalized_params
       end
 
       private
 
-      attr_reader :params
+      attr_reader :params, :normalized_params
 
     end
   end

--- a/spec/griddler/adapters/cloudmailin_adapter_spec.rb
+++ b/spec/griddler/adapters/cloudmailin_adapter_spec.rb
@@ -25,6 +25,14 @@ describe Griddler::Adapters::CloudmailinAdapter, '.normalize_params' do
     normalized_params[:attachments].should be_empty
   end
 
+  it 'gets rid of the original cloudmailin params' do
+    params = default_params
+
+    normalized_params = Griddler::Adapters::CloudmailinAdapter.normalize_params(params)
+
+    normalized_params[:envelope].should be_nil
+  end
+
   def default_params
     params = {
       envelope: { to: 'Some Identifier <some-identifier@example.com>', from: 'Joe User <joeuser@example.com>' },


### PR DESCRIPTION
This is based off what you asked for in #38.
