### PR TITLE
configuration not accepting :postmark for email service

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    griddler (0.3.1)
+    griddler (0.4.0)
       htmlentities
       rails (>= 3.2.0)
 
@@ -51,7 +51,7 @@ GEM
       i18n (>= 0.4.0)
       mime-types (~> 1.16)
       treetop (~> 1.4.8)
-    mime-types (1.19)
+    mime-types (1.21)
     multi_json (1.3.6)
     polyglot (0.3.3)
     rack (1.4.1)
@@ -102,7 +102,7 @@ GEM
     treetop (1.4.12)
       polyglot
       polyglot (>= 0.3.1)
-    tzinfo (0.3.35)
+    tzinfo (0.3.37)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ end
 * `config.to` is the format of the returned value for the `:to` key in
 the email object. `:hash` will return all options within a -- (surprise!) -- hash.
 * `config.email_service` tells Griddler which email service you are using. The supported
-email service options are :sendgrid (the default), :cloudmailin (expects
-multipart format) and :postmark
+email service options are `:sendgrid` (the default), `:cloudmailin` (expects
+multipart format) and `:postmark`.
 
 Testing In Your App
 -------------------

--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -44,6 +44,7 @@ module Griddler
       {
         sendgrid: Griddler::Adapters::SendgridAdapter,
         cloudmailin: Griddler::Adapters::CloudmailinAdapter,
+        postmark: Griddler::Adapters::PostmarkAdapter,
       }
     end
   end

--- a/spec/griddler/configuration_spec.rb
+++ b/spec/griddler/configuration_spec.rb
@@ -36,7 +36,7 @@ describe Griddler::Configuration do
 
       Griddler.configuration.processor_class.should eq dummy_processor
     end
-    
+
      it 'sets and stores an email_service' do
 
         Griddler.configure do |config|
@@ -54,6 +54,18 @@ describe Griddler::Configuration do
       end
 
       config.should raise_error(Griddler::Errors::EmailServiceAdapterNotFound)
+    end
+
+    it "accepts all valid email service adapter settings" do
+      [:sendgrid, :cloudmailin, :postmark].each do |adapter|
+        config = lambda do
+          Griddler.configure do |config|
+            config.email_service = adapter
+          end
+        end
+
+        config.should_not raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
Configuration was throwing exceptions because :postmark key was not added to adapter class.

Thanks for the great gem!
