### PR TITLE
Add an adapter for Mandrill

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Griddler
 
 Griddler is a Rails engine (full plugin) that provides an endpoint for the
 [SendGrid parse api](http://sendgrid.com/docs/API%20Reference/Webhooks/parse.html),
-[Cloudmailin parse api](http://cloudmailin.com) or
-[Postmark parse api](http://developer.postmarkapp.com/developer-inbound-parse.html)
+[Cloudmailin parse api](http://cloudmailin.com),
+[Postmark parse api](http://developer.postmarkapp.com/developer-inbound-parse.html) or
+[Mandrill parse api](http://help.mandrill.com/entries/21699367-Inbound-Email-Processing-Overview)
 that hands off a built email object to a class implemented by you.
 
 Tutorials
@@ -113,7 +114,7 @@ end
 the email object. `:hash` will return all options within a -- (surprise!) -- hash.
 * `config.email_service` tells Griddler which email service you are using. The supported
 email service options are `:sendgrid` (the default), `:cloudmailin` (expects
-multipart format) and `:postmark`.
+multipart format), `:postmark` and `:mandrill`.
 
 Testing In Your App
 -------------------
@@ -200,6 +201,24 @@ def pick_meaningful_recipient(recipients)
 end
 ```
 
+Using Griddler with Mandrill
+----------------------------
+
+When adding a webhook in their administration panel, Mandrill will issue a HEAD
+request to check if the webhook is valid (see
+[Adding Routes](http://help.mandrill.com/entries/21699367-Inbound-Email-Processing-Overview)).
+If the HEAD request fails, Mandrill will not allow you to add the webhook.
+Since Griddler is only configured to handle POST requests, you will not be able
+to add the webhook as-is. To solve this, add a temporary route to your
+application that can handle the HEAD request:
+
+```ruby
+# routes.rb
+get '/email_processor', :to => proc { [200, {}, ["OK"]] }
+```
+
+Once you have correctly configured Mandrill, you can go ahead and delete this code.
+
 More Information
 ----------------
 
@@ -209,6 +228,8 @@ More Information
 * [Cloudmailin Docs](http://docs.cloudmailin.com/)
 * [Postmark](http://postmarkapp.com)
 * [Postmark Docs](http://developer.postmarkapp.com/)
+* [Mandrill](http://mandrill.com)
+* [Mandrill Docs](http://help.mandrill.com/forums/21092258-Inbound-Email-Processing)
 
 Credits
 -------

--- a/app/controllers/griddler/emails_controller.rb
+++ b/app/controllers/griddler/emails_controller.rb
@@ -1,12 +1,14 @@
 class Griddler::EmailsController < ActionController::Base
   def create
-    Griddler::Email.new(normalized_params).process
+    normalized_params.each do |p|
+      Griddler::Email.new(p).process
+    end
     head :ok
   end
 
   private
 
   def normalized_params
-    Griddler.configuration.email_service.normalize_params(params)
+    Array.wrap(Griddler.configuration.email_service.normalize_params(params))
   end
 end

--- a/lib/griddler.rb
+++ b/lib/griddler.rb
@@ -8,6 +8,7 @@ require 'griddler/configuration'
 require 'griddler/adapters/sendgrid_adapter'
 require 'griddler/adapters/cloudmailin_adapter'
 require 'griddler/adapters/postmark_adapter'
+require 'griddler/adapters/mandrill_adapter'
 
 module Griddler
 end

--- a/lib/griddler/adapters/mandrill_adapter.rb
+++ b/lib/griddler/adapters/mandrill_adapter.rb
@@ -1,0 +1,70 @@
+module Griddler
+  module Adapters
+    class MandrillAdapter
+      def initialize(params)
+        @params = params
+      end
+
+      def self.normalize_params(params)
+        adapter = new(params)
+        adapter.normalize_params
+      end
+
+      def normalize_params
+        events.map do |event|
+          {
+            to: recipients(event),
+            from: event[:from_email],
+            subject: event[:subject],
+            text: event[:text],
+            html: event[:html],
+            raw_body: event[:raw_msg],
+            attachments: attachment_files(event)
+          }
+        end
+      end
+
+      private
+
+      attr_reader :params
+
+      def events
+        @events ||= ActiveSupport::JSON.decode(params[:mandrill_events]).map do |event|
+          event['msg'].with_indifferent_access
+        end
+      end
+
+      def recipients(event)
+        event[:to].map { |recipient| full_email(recipient) }
+      end
+
+      def full_email(contact_info)
+        email = contact_info[0]
+        if contact_info[1]
+          "#{contact_info[1]} <#{email}>"
+        else
+          email
+        end
+      end
+
+      def attachment_files(event)
+        attachments = event[:attachments] || Array.new
+        attachments.map do |key, attachment|
+          ActionDispatch::Http::UploadedFile.new({
+            filename: attachment[:name],
+            type: attachment[:type],
+            tempfile: create_tempfile(attachment)
+          })
+        end
+      end
+
+      def create_tempfile(attachment)
+        filename = attachment[:name]
+        tempfile = Tempfile.new(filename, Dir::tmpdir, encoding: 'ascii-8bit')
+        tempfile.write(Base64.decode64(attachment[:content]))
+        tempfile.rewind
+        tempfile
+      end
+    end
+  end
+end

--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -56,6 +56,7 @@ module Griddler
         sendgrid: Griddler::Adapters::SendgridAdapter,
         cloudmailin: Griddler::Adapters::CloudmailinAdapter,
         postmark: Griddler::Adapters::PostmarkAdapter,
+        mandrill: Griddler::Adapters::MandrillAdapter,
       }
     end
   end

--- a/spec/controllers/griddler/emails_controller_spec.rb
+++ b/spec/controllers/griddler/emails_controller_spec.rb
@@ -19,7 +19,6 @@ describe Griddler::EmailsController do
     end
   end
 
-
   def email_params
     {
       headers: 'Received: by 127.0.0.1 with SMTP...',

--- a/spec/features/adapters_and_email_spec.rb
+++ b/spec/features/adapters_and_email_spec.rb
@@ -1,20 +1,24 @@
 require 'spec_helper'
 
 describe 'Adapters act the same' do
-  [:sendgrid, :postmark, :cloudmailin].each do |adapter|
+  [:sendgrid, :postmark, :cloudmailin, :mandrill].each do |adapter|
     context adapter do
       it "wraps recipients in an array and passes them to Email by #{adapter}" do
         Griddler.configuration.email_service = adapter
 
         normalized_params = Griddler.configuration.email_service.normalize_params(params_for[adapter])
-        email = Griddler::Email.new(normalized_params)
 
-        email.to.should eq([{
-          token: 'hi',
-          host: 'example.com',
-          full: 'Hello World <hi@example.com>',
-          email: 'hi@example.com'
-        }])
+        Array.wrap(normalized_params).each do |params|
+          email = Griddler::Email.new(params)
+
+          email.to.should eq([{
+            token: 'hi',
+            host: 'example.com',
+            full: 'Hello World <hi@example.com>',
+            email: 'hi@example.com'
+          }])
+        end
+
       end
     end
   end
@@ -45,6 +49,16 @@ def params_for
       text: 'hi',
       to: 'Hello World <hi@example.com>',
       from: 'There <there@example.com>',
+    },
+    mandrill: {
+      mandrill_events: ActiveSupport::JSON.encode([{
+        msg: {
+          text: 'hi',
+          from_email: "there@example.com",
+          from_name: "There",
+          to: [["hi@example.com", "Hello World"]],
+        }
+      }])
     },
   }
 end

--- a/spec/griddler/adapters/mandrill_adapter_spec.rb
+++ b/spec/griddler/adapters/mandrill_adapter_spec.rb
@@ -1,0 +1,149 @@
+require 'spec_helper'
+
+describe Griddler::Adapters::MandrillAdapter, '.normalize_params' do
+  it 'normalizes parameters' do
+    params = default_params
+
+    normalized_params = Griddler::Adapters::MandrillAdapter.normalize_params(params)
+    normalized_params.each do |params|
+      params[:to].should eq ['The Token <token@reply.example.com>']
+      params[:from].should eq 'hernan@example.com'
+      params[:subject].should eq 'hello'
+      params[:text].should include('Dear bob')
+      params[:html].should include('<p>Dear bob</p>')
+      params[:raw_body].should include('raw')
+    end
+  end
+
+  it 'passes the received array of files' do
+    params = params_with_attachments
+
+    normalized_params = Griddler::Adapters::MandrillAdapter.normalize_params(params)
+
+    first, second = *normalized_params[0][:attachments]
+
+    first.original_filename.should eq('photo1.jpg')
+    first.size.should eq(upload_1_params[:length])
+
+    second.original_filename.should eq('photo2.jpg')
+    second.size.should eq(upload_2_params[:length])
+  end
+
+  it 'has no attachments' do
+    params = default_params
+
+    normalized_params = Griddler::Adapters::MandrillAdapter.normalize_params(params)
+
+    normalized_params[0][:attachments].should be_empty
+  end
+
+  def default_params
+    mandrill_events (params_hash*2).to_json
+  end
+
+  def params_hash
+    [{
+      event: "inbound",
+      ts: 1364601140,
+      msg:
+        {
+          raw_msg: "raw",
+          headers: {},
+          text: text_body,
+          html: text_html,
+          from_email: "hernan@example.com",
+          from_name: "Hernan Example",
+          to: [["token@reply.example.com", "The Token"]],
+          subject: "hello",
+          spam_report: {
+            score: -0.8,
+            matched_rules: "..."
+            },
+          dkim: {signed: true, valid: true},
+          spf: {result: "pass", detail: "sender SPF authorized"},
+          email: "token@reply.example.com",
+          tags: [],
+          sender: nil
+        }
+    }]
+  end
+
+  def params_with_attachments
+    params = params_hash
+    params[0][:msg][:attachments] = {
+      'photo1.jpg' => upload_1_params,
+      'photo2.jpg' => upload_2_params
+    }
+    mandrill_events params.to_json
+  end
+
+  def mandrill_events(json)
+    { mandrill_events: json }
+  end
+
+  def text_body
+    <<-EOS.strip_heredoc.strip
+      Dear bob
+
+      Reply ABOVE THIS LINE
+
+      hey sup
+    EOS
+  end
+
+  def text_html
+    <<-EOS.strip_heredoc.strip
+      <p>Dear bob</p>
+
+      Reply ABOVE THIS LINE
+
+      hey sup
+    EOS
+  end
+
+  def cwd
+    File.expand_path File.dirname(__FILE__)
+  end
+
+  def upload_1_params
+    @upload_1_params ||= begin
+      file = File.new("#{cwd}/../../../spec/fixtures/photo1.jpg")
+      size = file.size
+      {
+        name: 'photo1.jpg',
+        content: Base64.encode64(file.read),
+        type: 'image/jpeg',
+        length: file.size
+      }
+    end
+  end
+
+  def upload_2_params
+    @upload_2_params ||= begin
+      file = File.new("#{cwd}/../../../spec/fixtures/photo2.jpg")
+      size = file.size
+      {
+        name: 'photo2.jpg',
+        content: Base64.encode64(file.read),
+        type: 'image/jpeg',
+        length: file.size
+      }
+    end
+  end
+
+  def upload_1
+    @upload_1 ||= ActionDispatch::Http::UploadedFile.new({
+      filename: 'photo1.jpg',
+      type: 'image/jpeg',
+      tempfile: File.new("#{cwd}/../../../spec/fixtures/photo1.jpg")
+    })
+  end
+
+  def upload_2
+    @upload_2 ||= ActionDispatch::Http::UploadedFile.new({
+      filename: 'photo2.jpg',
+      type: 'image/jpeg',
+      tempfile: File.new("#{cwd}/../../../spec/fixtures/photo2.jpg")
+    })
+  end
+end

--- a/spec/griddler/configuration_spec.rb
+++ b/spec/griddler/configuration_spec.rb
@@ -65,7 +65,7 @@ describe Griddler::Configuration do
     end
 
     it "accepts all valid email service adapter settings" do
-      [:sendgrid, :cloudmailin, :postmark].each do |adapter|
+      [:sendgrid, :cloudmailin, :postmark, :mandrill].each do |adapter|
         config = lambda do
           Griddler.configure do |c|
             c.email_service = adapter


### PR DESCRIPTION
I want to start using Griddler in our app, but we use Mandrill, for which there wasn't an adapter yet, so I wrote it.
I still would appreciate some feedback, though:
- Mandrill's requests could possibly contain more than one email, as they batch them up into one request, so `normalized_params` returns an array. ~~For this to work, I made a new `Griddler::Email.process` method that takes a single hash or an array of hashes, instantiates a new `Griddler::Email` for each hash passed, and then calls `#process` on those instances. I don't know if that's the approach that you would like in this case, but it had the least impact on the public API.~~ The controller processes the array of inbound emails.
- ~~I wrote tests for the adapter (based on the tests that were there for another adapter), but I'm not sure where/how to test this new `process` method (I'm not very experienced with testing, and would appreciate some pointers).~~ This no longer applies.
- ~~I had to add a new route, because Mandrill does a HEAD request at the endpoint to check if it's valid before letting a user add it to their system.~~ Route removed.
