### PR TITLE
Update README factory example to new recipient api

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ following sample factory.
 
 ```ruby
 factory :email, class: OpenStruct do
-  to 'email-token'
+  # Assumes Griddler.configure.to is :hash (default)
+  to [{ raw: 'to_user@email.com', email: 'to_user@email.com', token: 'to_user', host: 'email.com' }]
   from 'user@email.com'
   subject 'email subject'
   body 'Hello!'


### PR DESCRIPTION
Original PR was #48; the "Testing in your App" part of the README was overlooked. This fixes that :)

cc @calebthompson
