### PR TITLE
Force controller spec to use sendgrid adapter

### DIFF
--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -46,6 +46,10 @@ module Griddler
     end
 
     def email_service=(new_email_service)
+      if new_email_service == :default
+        new_email_service = :sendgrid
+      end
+
       @email_service_adapter = adapter_class.fetch(new_email_service) { raise Griddler::Errors::EmailServiceAdapterNotFound }
     end
 

--- a/spec/griddler/adapters/mandrill_adapter_spec.rb
+++ b/spec/griddler/adapters/mandrill_adapter_spec.rb
@@ -41,6 +41,10 @@ describe Griddler::Adapters::MandrillAdapter, '.normalize_params' do
     mandrill_events (params_hash*2).to_json
   end
 
+  def mandrill_events(json)
+    { mandrill_events: json }
+  end
+
   def params_hash
     [{
       event: "inbound",
@@ -75,10 +79,6 @@ describe Griddler::Adapters::MandrillAdapter, '.normalize_params' do
       'photo2.jpg' => upload_2_params
     }
     mandrill_events params.to_json
-  end
-
-  def mandrill_events(json)
-    { mandrill_events: json }
   end
 
   def text_body

--- a/spec/griddler/configuration_spec.rb
+++ b/spec/griddler/configuration_spec.rb
@@ -46,13 +46,20 @@ describe Griddler::Configuration do
     end
 
      it 'sets and stores an email_service' do
-
         Griddler.configure do |config|
           config.email_service = :cloudmailin
         end
 
         Griddler.configuration.email_service.should eq(Griddler::Adapters::CloudmailinAdapter)
+     end
+
+    it 'accepts a :default symbol and uses sendgrid' do
+      Griddler.configure do |c|
+        c.email_service = :default
       end
+
+      Griddler.configuration.email_service.should eq(Griddler::Adapters::SendgridAdapter)
+    end
 
     it 'raises an error when setting a non-existent email service adapter' do
       config = lambda do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,4 +7,8 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_base_class_for_anonymous_controllers = false
   config.order = "random"
+
+  config.before :each do
+    Griddler.configuration.email_service = :default
+  end
 end


### PR DESCRIPTION
spec/features/adapters_and_email_spec.rb:9 was intermittently leaking the
configuration across tests and causing the controller spec to think it was
using the mandrill or cloudmailin adapter. Instead it should default to
sendgrid, which matches up more closely to the sample email params we're
posting to the action.

Further changes:
- Formatting and spacing, newlines after blocks, etc.
- Limit to 80 chars
- Move a method up in mandrill adapter spec for easier reading/comprehension
