### PR TITLE
Easily reply to Griddler::Emails with ActionMailer

### DIFF
--- a/lib/griddler/reply_mixin.rb
+++ b/lib/griddler/reply_mixin.rb
@@ -1,0 +1,70 @@
+module Griddler
+  module ReplyMixin
+    def reply(email, headers={}, &block)
+      reply = Reply.new(email)
+      mail(reply.headers.merge(headers), &block)
+    end
+
+    private
+
+    class Reply
+      def initialize(email)
+        @email = email
+      end
+
+      def headers
+        { to: reply_address, subject: subject }.merge(identity_headers)
+      end
+
+      private
+
+      attr_reader :email
+
+      def reply_address
+        email.headers['Reply-To'] || email.from
+      end
+
+      def subject
+        "Re: #{original_subject}"
+      end
+
+      def original_subject
+        email.subject.sub(/^Re:\s+/, '')
+      end
+
+      def identity_headers
+        if parent_has_message_id?
+          { 'In-Reply-To' => parent_message_id, 'References' => references }
+        else
+          {}
+        end
+      end
+
+      def parent_has_message_id?
+        parent_message_id.present?
+      end
+
+      def references
+        [parent_references, parent_message_id].compact.join(' ')
+      end
+
+      def parent_message_id
+        email.headers['Message-ID']
+      end
+
+      def parent_references
+        email.headers['References'] || parent_single_in_reply_to
+      end
+
+      def parent_single_in_reply_to
+        unless parent_in_reply_to =~ /\s/
+          parent_in_reply_to
+        end
+      end
+
+      def parent_in_reply_to
+        email.headers['In-Reply-To']
+      end
+    end
+  end
+end

--- a/spec/dummy/app/mailers/replying_mailer.rb
+++ b/spec/dummy/app/mailers/replying_mailer.rb
@@ -1,0 +1,14 @@
+require 'griddler/reply_mixin'
+
+class ReplyingMailer < ActionMailer::Base
+  include Griddler::ReplyMixin
+
+  default from: 'info@myapp.example.com'
+
+  def response(email)
+    reply(email) do |format|
+      format.text { render text: 'The text version of the email!' }
+      format.html
+    end
+  end
+end

--- a/spec/dummy/app/views/replying_mailer/response.html.erb
+++ b/spec/dummy/app/views/replying_mailer/response.html.erb
@@ -1,0 +1,1 @@
+<p>The HTML version of the email!</p>

--- a/spec/griddler/reply_mixin_spec.rb
+++ b/spec/griddler/reply_mixin_spec.rb
@@ -1,0 +1,152 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'griddler/reply_mixin'
+
+class DummyMailer
+  include Griddler::ReplyMixin
+end
+
+describe Griddler::ReplyMixin, '#reply' do
+  let(:mailer) do
+    DummyMailer.new.tap { |mailer| mailer.stub(:mail) }
+  end
+
+  describe 'setting the subject (RFC 5322 § 3.6.5)' do
+    it 'prefixes the original subject with Re:' do
+      email = build_email(subject: 'Hello')
+
+      mailer.should_receive(:mail).with(hash_including(subject: 'Re: Hello'))
+      mailer.reply(email)
+    end
+
+    it 'does not create a duplicate prefix' do
+      email = build_email(subject: 'Re: Important')
+
+      mailer.should_receive(:mail).with(hash_including(subject: 'Re: Important'))
+      mailer.reply(email)
+    end
+  end
+
+  describe 'setting the recipient (RFC 5322 § 3.6.2)' do
+    it 'prefers to use the Reply-To header' do
+      email = build_email(
+        from: '"Jane Doe" <jane@example.com>',
+        headers: %Q(Reply-To: "John Doe" <john@example.com>\r\n)
+      )
+
+      mailer.should_receive(:mail).with(hash_including(to: '"John Doe" <john@example.com>'))
+      mailer.reply(email)
+    end
+
+    it 'uses the From header when Reply-To is not set' do
+      email = build_email(from: '"Jane Doe" <jane@example.com>')
+
+      mailer.should_receive(:mail).with(hash_including(to: 'jane@example.com'))
+      mailer.reply(email)
+    end
+  end
+
+  describe 'setting the reply headers (RFC 5322 § 3.6.4)' do
+    describe 'from a parent with no identifying headers' do
+      it 'does not set any headers' do
+        email = build_email(headers: '')
+
+        mailer.should_receive(:mail) do |headers|
+          headers.should_not have_key('In-Reply-To')
+          headers.should_not have_key('References')
+        end
+        mailer.reply(email)
+      end
+    end
+
+    describe 'from a parent with only a Message-ID' do
+      it 'sets In-Reply-To and References' do
+        email = build_email(headers: 'Message-ID: <1@example.com>')
+
+        mailer.should_receive(:mail).with(hash_including(
+          'In-Reply-To' => '<1@example.com>',
+          'References' => '<1@example.com>'
+        ))
+        mailer.reply(email)
+      end
+    end
+
+    describe 'from a parent with Message-ID, In-Reply-To & References' do
+      it 'sets In-Reply-To and References' do
+        email = build_email(headers: [
+          'Message-ID: <3@example.com>',
+          'In-Reply-To: <2@example.com>',
+          'References: <1@example.com> <2@example.com>'
+        ].join("\r\n"))
+
+        mailer.should_receive(:mail).with(hash_including(
+          'In-Reply-To' => '<3@example.com>',
+          'References' => '<1@example.com> <2@example.com> <3@example.com>'
+        ))
+        mailer.reply(email)
+      end
+    end
+
+    describe 'from a parent with a Message-ID and a single In-Reply-To' do
+      it 'sets In-Reply-To and References' do
+        email = build_email(headers: [
+          'Message-ID: <2@example.com>',
+          'In-Reply-To: <1@example.com>'
+        ].join("\r\n"))
+
+        mailer.should_receive(:mail).with(hash_including(
+          'In-Reply-To' => '<2@example.com>',
+          'References' => '<1@example.com> <2@example.com>'
+        ))
+        mailer.reply(email)
+      end
+    end
+
+    describe 'from a parent with a Message-ID and a multiple In-Reply-To' do
+      it 'sets In-Reply-To and References' do
+        email = build_email(headers: [
+          'Message-ID: <3@example.com>',
+          'In-Reply-To: <1@example.com> <2@example.com>'
+        ].join("\r\n"))
+
+        mailer.should_receive(:mail).with(hash_including(
+          'In-Reply-To' => '<3@example.com>',
+          'References' => '<3@example.com>'
+        ))
+        mailer.reply(email)
+      end
+    end
+  end
+
+  describe 'accepting custom arguments' do
+    it 'passes them on to `mail`' do
+      email = build_email(subject: 'Hello world', from: 'you@example.com')
+
+      mailer.should_receive(:mail).with(hash_including(
+        to: 'you@example.com',
+        from: 'me@example.com',
+        subject: 'Goodbye world'
+      ))
+      mailer.reply(email, subject: 'Goodbye world', from: 'me@example.com')
+    end
+
+    it 'passes the given block on to `mail`' do
+      format = double.tap { |f| f.stub(:html) }
+      mailer.stub(:mail).and_yield(format)
+
+      format.should_receive(:html).with(text: '<p>Hello!</p>')
+      mailer.reply(build_email) { |format| format.html text: '<p>Hello!</p>' }
+    end
+  end
+
+  def build_email(params={})
+    Griddler::Email.new({
+      headers: '',
+      to: ['recipient@example.com'],
+      from: 'sender@example.com',
+      subject: 'Hello',
+      text: 'Hello there!'
+    }.merge(params))
+  end
+end

--- a/spec/integration/replying_mailer_spec.rb
+++ b/spec/integration/replying_mailer_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe ReplyingMailer, '#response' do
+  it 'builds an RFC 5322 compliant reply' do
+    email = Griddler::Email.new(
+      headers: [
+        'Message-ID: <3@example.com>',
+        'In-Reply-To: <2@example.com>',
+        'References: <1@example.com> <2@example.com>',
+        'Reply-To: me@example.com'
+      ].join("\r\n"),
+      to: ['recipient@example.com'],
+      from: 'sender@example.com',
+      subject: 'Hello world',
+      text: 'This is just a test email'
+    )
+
+    reply = ReplyingMailer.response(email)
+
+    reply.to.should eq ['me@example.com']
+    reply.from.should eq ['info@myapp.example.com']
+    reply.subject.should eq 'Re: Hello world'
+    reply.header['In-Reply-To'].value.should eq '<3@example.com>'
+    reply.header['References'].value.should eq '<1@example.com> <2@example.com> <3@example.com>'
+    reply.html_part.body.should match %r(<p>The HTML version of the email!</p>)
+    reply.text_part.body.should match %r(The text version of the email!)
+  end
+end


### PR DESCRIPTION
Extracted from a side project I'm working on that runs emails through Google
Translate and replies with an English version. The tests are a little repetitive,
but I'd appreciate feedback on the concept before I do the final tidying up.

Provides a mixin that can be included into ActionMailer::Base subclasses to
easily create replies to Griddler emails that are compliant with the various
reply-related requirements of RFC 5322:
- Selecting the correct recipient using Reply-To or From (§ 3.6.2)
- Setting the In-Reply-To and References headers for message threading (§ 3.6.4)
- Prefixing the subject with "Re:" while avoiding double-prefixes (§ 3.6.5)

Example use:

```
# app/mailers/my_mailer.rb
require 'griddler/reply_mixin'

class MyMailer < ActionMailer::Base
  include Griddler::ReplyMixin

  default from: 'info@example.com'

  def response(email)
    reply(email, subject: 'Override the default reply subject')
  end
end

# app/models/email_processor.rb
class EmailProcessor
  def self.process(email)
    MyMailer.response(email).deliver
  end
end
```
