### PR TITLE
Return the name part of the email address in the 'to' hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ information of each recipient:
   * `email`: The email address of the recipient.
 
   * `full`: The whole recipient field. E.g, `Some User <hello@example.com>`
+  * `name`: The name of the recipient. E.g, `Some User`
 
 `.from` will default to the `email` value of a hash like `.to`, and can be
 configured to return the full hash.
@@ -127,7 +128,8 @@ Griddler.configure do |config|
   # :raw    => 'AppName <s13.6b2d13dc6a1d33db7644@mail.myapp.com>'
   # :email  => 's13.6b2d13dc6a1d33db7644@mail.myapp.com'
   # :token  => 's13.6b2d13dc6a1d33db7644'
-  # :hash   => { raw: [...], email: [...], token: [...], host: [...] }
+  # :hash   => { raw: [...], email: [...], token: [...], host: [...],
+name: [...] }
   config.reply_delimiter = '-- REPLY ABOVE THIS LINE --'
   config.email_service = :sendgrid # :cloudmailin, :postmark, :mandrill
 end
@@ -151,7 +153,7 @@ following sample factory.
 ```ruby
 factory :email, class: OpenStruct do
   # Assumes Griddler.configure.to is :hash (default)
-  to [{ raw: 'to_user@email.com', email: 'to_user@email.com', token: 'to_user', host: 'email.com' }]
+  to [{ full: 'to_user@email.com', email: 'to_user@email.com', token: 'to_user', host: 'email.com', name: nil }]
   from 'user@email.com'
   subject 'email subject'
   body 'Hello!'

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -13,12 +13,14 @@ require 'mail'
 module Griddler::EmailParser
   def self.parse_address(full_address)
     email_address = extract_email_address(full_address)
+    name = extract_name(full_address)
     token, host = split_address(email_address)
     {
       token: token,
       host: host,
       email: email_address,
       full: full_address,
+      name: name,
     }
   end
 
@@ -55,6 +57,14 @@ module Griddler::EmailParser
 
   def self.extract_email_address(full_address)
     full_address.split('<').last.delete('>').strip
+  end
+
+  def self.extract_name(full_address)
+    full_address = full_address.strip
+    name = full_address.split('<').first.strip
+    if name.present? && name != full_address
+      name
+    end
   end
 
   def self.split_address(email_address)

--- a/spec/features/adapters_and_email_spec.rb
+++ b/spec/features/adapters_and_email_spec.rb
@@ -15,7 +15,8 @@ describe 'Adapters act the same' do
             token: 'hi',
             host: 'example.com',
             full: 'Hello World <hi@example.com>',
-            email: 'hi@example.com'
+            email: 'hi@example.com',
+            name: 'Hello World',
           }])
         end
 

--- a/spec/support/examples/configurable_email_address.rb
+++ b/spec/support/examples/configurable_email_address.rb
@@ -17,6 +17,7 @@ shared_examples_for 'configurable email address' do |address|
         host: 'example.com',
         email: 'caleb@example.com',
         full: 'Caleb Thompson <caleb@example.com>',
+        name: 'Caleb Thompson',
       }
     end
   end


### PR DESCRIPTION
I need this for a project I am working on and I think it doesn't go against what the purpose of this gem is. Wow, that was a really awkward way to say that. 

I am not thrilled with how I had to test this. I had to pass name: nil to a lot of them which I think is not what we want.  It looks like the test data is setup in each test so it may be best to change 

```
    @hash = {
      full: 'Bob <bob@example.com>',
      email: 'bob@example.com',
      token: 'bob',
      host: 'example.com',
      name: 'Bob',
    }
```

to

```
    @hash = {
      full: '<bob@example.com>',
      email: 'bob@example.com',
      token: 'bob',
      host: 'example.com',
      name: nil,
    }
```

You can see what I'm talking about here: https://github.com/r38y/griddler/commit/db8dbeeb080fed8a76a68f37a02ab64ce5026fca

Actually, I'm not sure one way is better than the other. 
