### PR TITLE
Update the Postmark adapter to return the full from email address.

### DIFF
--- a/lib/griddler/adapters/postmark_adapter.rb
+++ b/lib/griddler/adapters/postmark_adapter.rb
@@ -13,7 +13,7 @@ module Griddler
       def normalize_params
         {
           to: extract_recipients,
-          from: params[:FromFull][:Email],
+          from: full_email(params[:FromFull]),
           subject: params[:Subject],
           text: params[:TextBody],
           html: params[:HtmlBody],

--- a/spec/griddler/adapters/postmark_adapter_spec.rb
+++ b/spec/griddler/adapters/postmark_adapter_spec.rb
@@ -4,7 +4,7 @@ describe Griddler::Adapters::PostmarkAdapter, '.normalize_params' do
   it 'normalizes parameters' do
     Griddler::Adapters::PostmarkAdapter.normalize_params(default_params).should be_normalized_to({
       to: ['Robert Paulson <bob@example.com>'],
-      from: 'tdurden@example.com',
+      from: 'Tyler Durden <tdurden@example.com>',
       subject: 'Reminder: First and Second Rule',
       text: /Dear bob/,
       html: %r{<p>Dear bob</p>}


### PR DESCRIPTION
This is needed so that the name in the hash form of the from address doesn't return nil all the time for the name. It shouldn't be a breaking change for people using this adapter already. 
