### PR TITLE
Don't strip out the > for quotes. Closes #76

### DIFF
--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -31,7 +31,7 @@ module Griddler::EmailParser
       remove_reply_portion(body)
         .split(/[\r]*\n/)
         .reject do |line|
-          line =~ /^\s*>/ ||
+          line =~ /^\s+>/ ||
             line =~ /^\s*Sent from my /
         end.
         join("\n").

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -224,6 +224,12 @@ describe Griddler::Email, 'body formatting' do
     body_from_email(:text, body).should eq body
   end
 
+  it 'preserves blockquotes' do
+    body = "> Hello.\n\n>another line"
+
+    body_from_email(:text, body).should eq body
+  end
+
   it 'handles empty body values' do
     body_from_email(:text, "").should eq ""
   end


### PR DESCRIPTION
">" is kind of the universal blockquote symbol so griddler shouldn't strip those out. 
