### PR TITLE
Authenticate the email endpoint if auth_token is configured.

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Griddler.configure do |config|
 name: [...] }
   config.reply_delimiter = '-- REPLY ABOVE THIS LINE --'
   config.email_service = :sendgrid # :cloudmailin, :postmark, :mandrill
+  config.auth_token = 'some-auth-token' # if present, use
+/email_processor?token=some-auth-token to be successful
 end
 ```
 
@@ -142,6 +144,8 @@ end
 * `config.email_service` tells Griddler which email service you are using. The
   supported email service options are `:sendgrid` (the default), `:cloudmailin`
   (expects multipart format), `:postmark` and `:mandrill`.
+* `config.auth_token` tells Griddler if it should use a token in the
+  email webhook and what it should be.
 
 Testing In Your App
 -------------------

--- a/app/controllers/griddler/emails_controller.rb
+++ b/app/controllers/griddler/emails_controller.rb
@@ -1,4 +1,6 @@
 class Griddler::EmailsController < ActionController::Base
+  before_filter :authorize, if: ->{ Griddler.configuration.auth_token }
+
   def create
     normalized_params.each do |p|
       Griddler::Email.new(p).process
@@ -10,5 +12,12 @@ class Griddler::EmailsController < ActionController::Base
 
   def normalized_params
     Array.wrap(Griddler.configuration.email_service.normalize_params(params))
+  end
+
+  def authorize
+    unless Griddler.configuration.auth_token == params[:token]
+      render text: 'Please use a token', status: :unauthorized
+      return false
+    end
   end
 end

--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -16,7 +16,7 @@ module Griddler
   end
 
   class Configuration
-    attr_accessor :processor_class, :reply_delimiter
+    attr_accessor :processor_class, :reply_delimiter, :auth_token
 
     def to
       @to ||= :hash

--- a/spec/controllers/griddler/emails_controller_spec.rb
+++ b/spec/controllers/griddler/emails_controller_spec.rb
@@ -8,6 +8,22 @@ describe Griddler::EmailsController do
       response.should be_success
     end
 
+    it 'is successful with auth token' do
+      Griddler.configuration.stub(auth_token: 'auth_token')
+
+      post :create, email_params.merge(token: Griddler.configuration.auth_token)
+
+      response.should be_success
+    end
+
+    it 'returns unauthorized if wrong token' do
+      Griddler.configuration.stub(auth_token: 'auth_token')
+
+      post :create, email_params.merge(token: 'wrong token')
+
+      response.response_code.should eq 401
+    end
+
     it 'creates a new Griddler::Email with the given params' do
       email = double(process: 'something')
       Griddler::Email.should_receive(:new).

--- a/spec/griddler/configuration_spec.rb
+++ b/spec/griddler/configuration_spec.rb
@@ -28,6 +28,18 @@ describe Griddler::Configuration do
       Griddler.configuration.to.should eq :full
     end
 
+    it 'stores auth token' do
+      Griddler.configure do |config|
+        config.auth_token = 'auth_token'
+      end
+
+      Griddler.configuration.auth_token.should eq 'auth_token'
+    end
+
+    it 'defaults auth_token to nil' do
+      Griddler.configuration.auth_token.should be_nil
+    end
+
     it 'warns when setting token' do
       Kernel.should_receive(:warn)
 


### PR DESCRIPTION
If an auth token is configured the webhook must have the token present in the params as `:token` to stand a chance of being successful. 

I think this may be good if someone who is malicious guesses an app is using Griddler with the default endpoint. 

Part of me thinks this may not be necessary if your email processor is checking the `to` param for certain tokens. However, someone may be less strict and just check the `from` to take action. 

What do you think? 
