### PR TITLE
Griddler doesn't preserve ending newlines at the end of the body

### DIFF
--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -219,7 +219,7 @@ describe Griddler::Email, 'body formatting' do
   end
 
   it 'should preserve empty lines' do
-    body = "Hello.\n\nWhat's up?"
+    body = "Hello.\n\nWhat's up?\n"
 
     body_from_email(:text, body).should eq body
   end


### PR DESCRIPTION
Not sure if this is worth fixing, but it looks like we aren't preserving the final newline character when we're parsing out the reply.  This threw me off when I was constructing a different test case because I had to explicitly add a new line at the end to get the expected string to match the actual in some cases.
