### PR TITLE
[JRO] Better UTF-8 handling

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -68,33 +68,24 @@ module Griddler
     end
 
     def clean_text(text)
-      clean_invalid_utf8_bytes(text, 'text')
+      clean_invalid_utf8_bytes(text)
     end
 
     def clean_html(html)
-      cleaned_html = clean_invalid_utf8_bytes(html, 'html')
+      cleaned_html = clean_invalid_utf8_bytes(html)
       cleaned_html = strip_tags(cleaned_html)
       cleaned_html = HTMLEntities.new.decode(cleaned_html)
       cleaned_html
     end
 
-    def clean_invalid_utf8_bytes(text, email_part)
-      text.encode(
-        'UTF-8',
-        src_encoding(email_part),
-        invalid: :replace,
-        undef: :replace,
-        replace: ''
-      )
-    end
-
-    def src_encoding(email_part)
-      if params[:charsets]
-        charsets = ActiveSupport::JSON.decode(params[:charsets])
-        charsets[email_part]
-      else
-        'binary'
+    def clean_invalid_utf8_bytes(text)
+      if !text.valid_encoding?
+        text = text
+          .force_encoding('ISO-8859-1')
+          .encode('UTF-8')
       end
+
+      text
     end
   end
 end

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -19,11 +19,27 @@ describe Griddler::Email, 'body formatting' do
   end
 
   it 'handles invalid utf-8 bytes in html' do
-    body_from_email(:html, "Hello.\xF5").should eq 'Hello.'
+    body_from_email(:html, "Hell\xC0.").should eq 'HellÀ.'
   end
 
   it 'handles invalid utf-8 bytes in text' do
-    body_from_email(:text, "Hello.\xF5").should eq 'Hello.'
+    body_from_email(:text, "Hell\xF6.").should eq 'Hellö.'
+  end
+
+  it 'handles valid utf-8 bytes in html' do
+    body_from_email(:html, "Hell\xF1.").should eq 'Hellñ.'
+  end
+
+  it 'handles valid utf-8 bytes in text' do
+    body_from_email(:text, "Hell\xF2.").should eq 'Hellò.'
+  end
+
+  it 'handles valid utf-8 char in html' do
+    body_from_email(:html, "Hellö.").should eq 'Hellö.'
+  end
+
+  it 'handles valid utf-8 char in text' do
+    body_from_email(:text, "Hellö.").should eq 'Hellö.'
   end
 
   it 'does not remove invalid utf-8 bytes if charset is set' do


### PR DESCRIPTION
Re: issue #72

Dropped into pry to play around with this a bit and found a manner to force
encoding and handling to be a little less ... delete'y / text-stripping'y?

Tests now check for both a byte/octet and an actual UTF-8 character within the
context of both html and plain text. Looking at the content of an email object
here, ...

https://gist.github.com/dorra/6354910/raw/1dfa16fd7ad1d70a4286b15438c0472760b6c70d/sample_mail

... thanks to @dorra, provided some context as to where the improvement could
come.
