### PR TITLE
NameError w/ more info for missing EmailProcessor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "http://rubygems.org"
 
 gemspec
 
-version = ENV["RAILS_VERSION"] || "3.2"
+version = ENV["RAILS_VERSION"] || "4.0"
 
 rails = case version
 when "master"

--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -42,7 +42,18 @@ module Griddler
     end
 
     def processor_class
-      @processor_class ||= EmailProcessor
+      @processor_class ||=
+        begin
+          if Kernel.const_defined?(:EmailProcessor)
+            EmailProcessor
+          else
+            raise NameError.new(<<-ERROR.strip_heredoc, 'EmailProcessor')
+              To use Griddler, you must either define `EmailProcessor` or configure a
+              different processor. See https://github.com/thoughtbot/griddler#defaults for
+              more information.
+            ERROR
+          end
+        end
     end
 
     def processor_method

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -7,7 +7,7 @@ Dummy::Application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
-  config.eager_load = false
+  config.eager_load = true
 
   # Configure static asset server for tests with Cache-Control for performance
   config.serve_static_assets = true

--- a/spec/griddler/configuration_spec.rb
+++ b/spec/griddler/configuration_spec.rb
@@ -15,6 +15,12 @@ describe Griddler::Configuration do
       Griddler.configuration.email_service.should eq(Griddler::Adapters::SendgridAdapter)
       Griddler.configuration.processor_method.should eq(:process)
     end
+
+    it 'raises a helpful error if EmailProcessor is undefined' do
+      Kernel.stub(const_defined?: false)
+
+      expect { Griddler.configuration.processor_class }.to raise_error(NameError, %r{https://github\.com/thoughtbot/griddler#defaults})
+    end
   end
 
   describe 'with config block' do
@@ -98,7 +104,7 @@ describe Griddler::Configuration do
       config.should raise_error(Griddler::Errors::EmailServiceAdapterNotFound)
     end
 
-    it "accepts all valid email service adapter settings" do
+    it 'accepts all valid email service adapter settings' do
       [:sendgrid, :cloudmailin, :postmark, :mandrill, :mailgun].each do |adapter|
         config = lambda do
           Griddler.configure do |c|


### PR DESCRIPTION
When a NameError is raised because both Griddler.config.processor_class
has not been set and EmailProcessor is undefined, provide a more
informative message than `uninitialized constant EmailProcessor (NameError)`.
