### PR TITLE
Update Mandrill adapter to include From name.

### DIFF
--- a/lib/griddler/adapters/mandrill_adapter.rb
+++ b/lib/griddler/adapters/mandrill_adapter.rb
@@ -14,7 +14,7 @@ module Griddler
         events.map do |event|
           {
             to: recipients(event),
-            from: event[:from_email],
+            from: full_email([ event[:from_email], event[:from_name] ]),
             subject: event[:subject],
             text: event[:text],
             html: event[:html],

--- a/spec/griddler/adapters/mandrill_adapter_spec.rb
+++ b/spec/griddler/adapters/mandrill_adapter_spec.rb
@@ -7,7 +7,7 @@ describe Griddler::Adapters::MandrillAdapter, '.normalize_params' do
     Griddler::Adapters::MandrillAdapter.normalize_params(default_params).each do |params|
       params.should be_normalized_to({
         to: ['The Token <token@reply.example.com>'],
-        from: 'hernan@example.com',
+        from: 'Hernan Example <hernan@example.com>',
         subject: 'hello',
         text: %r{Dear bob},
         html: %r{<p>Dear bob</p>},


### PR DESCRIPTION
The Mandrill adapter was not parsing the sender's full name.
