### PR TITLE
CC processing: Added the ability to parse and process the list of cc address.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ that responds to:
 
 * `.to`
 * `.from`
+* `.cc`
 * `.subject`
 * `.body`
 * `.raw_text`
@@ -112,6 +113,9 @@ information of each recipient:
 
 `.from` will default to the `email` value of a hash like `.to`, and can be
 configured to return the full hash.
+
+`.cc` will be an array of the addresses in the Cc header, with an empty array
+if no addresses were present.
 
 `.attachments` will contain an array of attachments as multipart/form-data files
 which can be passed off to attachment libraries like Carrierwave or Paperclip.

--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -3,7 +3,7 @@ require 'htmlentities'
 module Griddler
   class Email
     include ActionView::Helpers::SanitizeHelper
-    attr_reader :to, :from, :subject, :body, :raw_body, :raw_text, :raw_html,
+    attr_reader :to, :from, :cc, :subject, :body, :raw_body, :raw_text, :raw_html,
       :headers, :raw_headers, :attachments
 
     def initialize(params)
@@ -19,6 +19,9 @@ module Griddler
       @raw_body = @raw_text || @raw_html
 
       @headers = extract_headers
+
+      @cc = extract_cc_from_headers @headers
+
       @raw_headers = params[:headers]
 
       @attachments = params[:attachments]
@@ -58,6 +61,10 @@ module Griddler
 
     def extract_headers
       EmailParser.extract_headers(params[:headers])
+    end
+
+    def extract_cc_from_headers(headers)
+      EmailParser.extract_cc(headers)
     end
 
     def text_or_sanitized_html

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -48,6 +48,12 @@ module Griddler::EmailParser
     end
   end
 
+  def self.extract_cc(headers)
+    headers.fetch('Cc', '').split(',').map do |address|
+      extract_email_address(address)
+    end
+  end
+
   private
 
   def self.reply_delimeter_regex

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -148,7 +148,7 @@ describe Griddler::Email, 'body formatting' do
 
     body_from_email(:text, body).should eq ''
   end
-  
+
   it 'handles "-----Original message-----" case insensitively' do
     body = <<-EOF
       Hello.
@@ -456,6 +456,30 @@ describe Griddler::Email, 'extracting email addresses' do
     ).process
     email.to.should eq [@hash.merge(full: "fake@example.com <#{@hash[:email]}>", name: 'fake@example.com')]
     email.from.should eq @hash[:email]
+  end
+end
+
+describe Griddler::Email, 'extracting email addresses from CC field' do
+  before do
+    @address = 'bob@example.com'
+    @headers = 'Cc: reply@example.com, foo <foo@example.com>'
+  end
+
+  it 'extracts the cc addresses as Array' do
+    email = Griddler::Email.new(to: [@address], from: @address, headers: @headers).process
+    email.cc.class.should eq Array
+  end
+
+
+  it 'returns an empty array when no CC address is added' do
+    email = Griddler::Email.new(to: [@address], from: @address).process
+    email.cc.should be_empty
+  end
+
+  it 'parses multiple emails' do
+    email = Griddler::Email.new(to: [@address], from: @address, headers: @headers).process
+    email.cc.should include('reply@example.com')
+    email.cc.should include('foo@example.com')
   end
 end
 


### PR DESCRIPTION
Too many times we've found that the users tend to move the reply address to the cc list.
That is the case that I'm trying to cover. To avoid monkey patching every time.

The behavior:
email.cc will default to an empty Array if it is not present.
email.cc will return a list of pure email addresses
