### PR TITLE
Makes CC a first class citizen with `to` and `from`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ information of each recipient:
 `.from` will default to the `email` value of a hash like `.to`, and can be
 configured to return the full hash.
 
-`.cc` will be an array of the addresses in the Cc header, with an empty array
-if no addresses were present.
+`.cc` behaves and can be configured like `.to`. If the adapter does not
+pass along a `cc` key then the headers will be parsed.
 
 `.attachments` will contain an array of attachments as multipart/form-data files
 which can be passed off to attachment libraries like Carrierwave or Paperclip.
@@ -134,6 +134,7 @@ Griddler.configure do |config|
   config.processor_class = EmailProcessor # MyEmailProcessor
   config.processor_method = :process # :custom_method
   config.to = :hash # :full, :email, :token
+  config.cc = :email # :full, :hash, :token
   config.from = :email # :full, :token, :hash
   # :raw    => 'AppName <s13.6b2d13dc6a1d33db7644@mail.myapp.com>'
   # :email  => 's13.6b2d13dc6a1d33db7644@mail.myapp.com'
@@ -148,7 +149,7 @@ end
 * `config.processor_class` is the class Griddler will use to handle your incoming emails.
 * `config.processor_method` is the method Griddler will call on the processor class when handling your incoming emails.
 * `config.reply_delimiter` is the string searched for that will split your body.
-* `config.to` and `config.from` are the format of the returned value for that
+* `config.to`, `config.cc` and `config.from` are the format of the returned value for that
   address in the email object. `:hash` will return all options within a -- (surprise!) -- hash.
 * `config.email_service` tells Griddler which email service you are using. The
   supported email service options are `:sendgrid` (the default), `:cloudmailin`

--- a/lib/griddler/adapters/cloudmailin_adapter.rb
+++ b/lib/griddler/adapters/cloudmailin_adapter.rb
@@ -13,6 +13,7 @@ module Griddler
       def normalize_params
         {
           to: params[:envelope][:to].split(','),
+          cc: ccs,
           from: params[:envelope][:from],
           subject: params[:headers][:Subject],
           text: params[:plain],
@@ -23,6 +24,10 @@ module Griddler
       private
 
       attr_reader :params
+
+      def ccs
+        params[:headers][:Cc].to_s.split(',').map(&:strip)
+      end
 
     end
   end

--- a/lib/griddler/adapters/mailgun_adapter.rb
+++ b/lib/griddler/adapters/mailgun_adapter.rb
@@ -13,6 +13,7 @@ module Griddler
       def normalize_params
         params.merge(
           to: recipients,
+          cc: ccs,
           text: params['body-plain'],
           html: params['body-html'],
           headers: params['message-headers'],
@@ -26,6 +27,22 @@ module Griddler
 
       def recipients
         params[:recipient].split(',')
+      end
+
+      def ccs
+        cc = if params[:Cc].present?
+          params[:Cc]
+        else
+          extract_header_cc
+        end
+        cc.split(',').map(&:strip)
+      end
+
+      def extract_header_cc
+        header = params['message-headers'].select{|h|
+          h.first == 'Cc'
+        }.first
+        header.to_a.last
       end
 
       def attachment_files

--- a/lib/griddler/adapters/mandrill_adapter.rb
+++ b/lib/griddler/adapters/mandrill_adapter.rb
@@ -14,6 +14,7 @@ module Griddler
         events.map do |event|
           {
             to: recipients(event),
+            cc: ccs(event),
             from: full_email([ event[:from_email], event[:from_name] ]),
             subject: event[:subject],
             text: event[:text],
@@ -36,6 +37,11 @@ module Griddler
 
       def recipients(event)
         event[:to].map { |recipient| full_email(recipient) }
+      end
+
+      def ccs(event)
+        found = event[:headers].select { |header| header.first == 'Cc' }.first
+        Array(found).last.to_s.split(',').map(&:strip)
       end
 
       def full_email(contact_info)

--- a/lib/griddler/adapters/postmark_adapter.rb
+++ b/lib/griddler/adapters/postmark_adapter.rb
@@ -12,7 +12,8 @@ module Griddler
 
       def normalize_params
         {
-          to: extract_recipients,
+          to: extract_recipients(:ToFull),
+          cc: extract_recipients(:CcFull),
           from: full_email(params[:FromFull]),
           subject: params[:Subject],
           text: params[:TextBody],
@@ -25,8 +26,8 @@ module Griddler
 
       attr_reader :params
 
-      def extract_recipients
-        params[:ToFull].map { |recipient| full_email(recipient) }
+      def extract_recipients(key)
+        params[key].to_a.map { |recipient| full_email(recipient) }
       end
 
       def full_email(contact_info)

--- a/lib/griddler/adapters/sendgrid_adapter.rb
+++ b/lib/griddler/adapters/sendgrid_adapter.rb
@@ -12,7 +12,8 @@ module Griddler
 
       def normalize_params
         params.merge(
-          to: recipients,
+          to: recipients(:to),
+          cc: recipients(:cc),
           attachments: attachment_files,
         )
       end
@@ -21,8 +22,8 @@ module Griddler
 
       attr_reader :params
 
-      def recipients
-        params[:to].split(',')
+      def recipients(key)
+        ( params[key] || '' ).split(',')
       end
 
       def attachment_files

--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -16,7 +16,7 @@ module Griddler
   end
 
   class Configuration
-    attr_accessor :processor_class, :processor_method, :reply_delimiter, :from
+    attr_accessor :processor_class, :processor_method, :reply_delimiter, :cc, :from
 
     def to
       @to ||= :hash
@@ -31,6 +31,10 @@ module Griddler
       end
 
       @to = type
+    end
+
+    def cc
+      @cc ||= :email
     end
 
     def from

--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -9,7 +9,7 @@ module Griddler
     def initialize(params)
       @params = params
 
-      @to = recipients
+      @to = recipients(:to)
       @from = extract_address(params[:from], config.from)
       @subject = params[:subject]
 
@@ -20,7 +20,7 @@ module Griddler
 
       @headers = extract_headers
 
-      @cc = extract_cc_from_headers @headers
+      @cc = recipients(:cc)
 
       @raw_headers = params[:headers]
 
@@ -41,8 +41,8 @@ module Griddler
       @config ||= Griddler.configuration
     end
 
-    def recipients
-      params[:to].map { |recipient| extract_address(recipient, config.to) }
+    def recipients(type=:to)
+      params[type].to_a.map { |recipient| extract_address(recipient, config.send(type)) }
     end
 
     def extract_address(address, type)

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -48,12 +48,6 @@ module Griddler::EmailParser
     end
   end
 
-  def self.extract_cc(headers)
-    headers.fetch('Cc', '').split(',').map do |address|
-      extract_email_address(address)
-    end
-  end
-
   private
 
   def self.reply_delimeter_regex

--- a/spec/controllers/griddler/emails_controller_spec.rb
+++ b/spec/controllers/griddler/emails_controller_spec.rb
@@ -23,6 +23,7 @@ describe Griddler::EmailsController do
     {
       headers: 'Received: by 127.0.0.1 with SMTP...',
       to: 'thoughtbot <tb@example.com>',
+      cc: 'CC <cc@example.com>',
       from: 'John Doe <someone@example.com>',
       subject: 'hello there',
       text: 'this is an email message',

--- a/spec/features/adapters_and_email_spec.rb
+++ b/spec/features/adapters_and_email_spec.rb
@@ -18,6 +18,7 @@ describe 'Adapters act the same' do
             email: 'hi@example.com',
             name: 'Hello World',
           }])
+          email.cc.should eq ['emily@example.com']
         end
 
       end
@@ -33,7 +34,7 @@ def params_for
         from: 'There <there@example.com>',
       },
       plain: 'hi',
-      headers: {},
+      headers: { Cc: 'emily@example.com' },
     },
     postmark: {
       FromFull: {
@@ -44,11 +45,16 @@ def params_for
         Email: 'hi@example.com',
         Name: 'Hello World',
       }],
+      CcFull: [{
+        Email: 'emily@example.com',
+        Name: '',
+      }],
       TextBody: 'hi',
     },
     sendgrid: {
       text: 'hi',
       to: 'Hello World <hi@example.com>',
+      cc: 'emily@example.com',
       from: 'There <there@example.com>',
     },
     mandrill: {
@@ -58,13 +64,15 @@ def params_for
           from_email: "there@example.com",
           from_name: "There",
           to: [["hi@example.com", "Hello World"]],
+          headers: [['Cc', 'emily@example.com']]
         }
       }])
     },
     mailgun: {
       recipient: 'Hello World <hi@example.com>',
       from: 'There <there@example.com>',
-      'body-plain' => 'hi'
+      Cc: 'emily@example.com',
+      'body-plain' => 'hi',
     }
   }
 end

--- a/spec/griddler/adapters/cloudmailin_adapter_spec.rb
+++ b/spec/griddler/adapters/cloudmailin_adapter_spec.rb
@@ -6,6 +6,7 @@ describe Griddler::Adapters::CloudmailinAdapter, '.normalize_params' do
   it 'normalizes parameters' do
     Griddler::Adapters::CloudmailinAdapter.normalize_params(default_params).should be_normalized_to({
       to: ['Some Identifier <some-identifier@example.com>'],
+      cc: ['emily@example.com'],
       from: 'Joe User <joeuser@example.com>',
       subject: 'Re: [ThisApp] That thing',
       text: /Dear bob/
@@ -27,9 +28,9 @@ describe Griddler::Adapters::CloudmailinAdapter, '.normalize_params' do
   end
 
   def default_params
-    params = {
+    {
       envelope: { to: 'Some Identifier <some-identifier@example.com>', from: 'Joe User <joeuser@example.com>' },
-      headers: { Subject: 'Re: [ThisApp] That thing' },
+      headers: { Subject: 'Re: [ThisApp] That thing', Cc: 'emily@example.com' },
       plain: <<-EOS.strip_heredoc.strip
         Dear bob
 

--- a/spec/griddler/adapters/mailgun_adapter_spec.rb
+++ b/spec/griddler/adapters/mailgun_adapter_spec.rb
@@ -6,11 +6,21 @@ describe Griddler::Adapters::MailgunAdapter, '.normalize_params' do
   it 'normalizes parameters' do
     Griddler::Adapters::MailgunAdapter.normalize_params(default_params).should be_normalized_to({
       to: ['alice@example.mailgun.org'],
+      cc: ['robert@example.mailgun.org'],
       from: 'Bob <bob@11crows.mailgun.org>',
       subject: 'Re: Sample POST request',
       text: %r{Dear bob},
       html: %r{<p>Dear bob</p>}
     })
+  end
+
+  it 'falls back to headers for cc' do
+    params = default_params.merge({
+      Cc: '',
+      'message-headers' => [['Cc', 'emily@example.mailgun.org']]
+    })
+    normalized_params = Griddler::Adapters::MailgunAdapter.normalize_params(params)
+    expect(normalized_params[:cc]).to eq ['emily@example.mailgun.org']
   end
 
   it 'passes the received array of files' do
@@ -34,11 +44,13 @@ describe Griddler::Adapters::MailgunAdapter, '.normalize_params' do
   def default_params
     params = {
       recipient: 'alice@example.mailgun.org',
+      Cc: 'robert@example.mailgun.org',
       sender: 'bob@example.mailgun.org',
       subject: 'Re: Sample POST request',
       from: 'Bob <bob@11crows.mailgun.org>',
       'body-plain' => text_body,
       'body-html' => text_html,
+      'message-headers' => []
     }
   end
 

--- a/spec/griddler/adapters/mandrill_adapter_spec.rb
+++ b/spec/griddler/adapters/mandrill_adapter_spec.rb
@@ -7,6 +7,7 @@ describe Griddler::Adapters::MandrillAdapter, '.normalize_params' do
     Griddler::Adapters::MandrillAdapter.normalize_params(default_params).each do |params|
       params.should be_normalized_to({
         to: ['The Token <token@reply.example.com>'],
+        cc: ['emily@example.mailgun.org'],
         from: 'Hernan Example <hernan@example.com>',
         subject: 'hello',
         text: %r{Dear bob},
@@ -53,7 +54,7 @@ describe Griddler::Adapters::MandrillAdapter, '.normalize_params' do
       msg:
         {
           raw_msg: "raw",
-          headers: {},
+          headers: [['Cc', 'emily@example.mailgun.org']],
           text: text_body,
           html: text_html,
           from_email: "hernan@example.com",

--- a/spec/griddler/adapters/postmark_adapter_spec.rb
+++ b/spec/griddler/adapters/postmark_adapter_spec.rb
@@ -6,11 +6,20 @@ describe Griddler::Adapters::PostmarkAdapter, '.normalize_params' do
   it 'normalizes parameters' do
     Griddler::Adapters::PostmarkAdapter.normalize_params(default_params).should be_normalized_to({
       to: ['Robert Paulson <bob@example.com>'],
+      cc: ['Jack <jack@example.com>'],
       from: 'Tyler Durden <tdurden@example.com>',
       subject: 'Reminder: First and Second Rule',
       text: /Dear bob/,
       html: %r{<p>Dear bob</p>}
     })
+  end
+
+  it 'handles CcFull of nil' do
+    no_cc_params = default_params
+    no_cc_params[:CcFull] = nil
+    normalized = Griddler::Adapters::PostmarkAdapter.normalize_params(no_cc_params)
+
+    expect(normalized[:cc]).to eq []
   end
 
   it 'passes the received array of files' do
@@ -39,6 +48,7 @@ describe Griddler::Adapters::PostmarkAdapter, '.normalize_params' do
     Griddler::Adapters::PostmarkAdapter.normalize_params(default_params).should be_normalized_to({
       ToFull: nil,
       FromFull: nil,
+      CcFull: nil,
       Subject:  nil,
       TextBody: nil,
       HtmlBody: nil,
@@ -55,6 +65,10 @@ describe Griddler::Adapters::PostmarkAdapter, '.normalize_params' do
       ToFull: [{
         Email: 'bob@example.com',
         Name: 'Robert Paulson'
+      }],
+      CcFull: [{
+        Email: 'jack@example.com',
+        Name: 'Jack'
       }],
       Subject: 'Reminder: First and Second Rule',
       TextBody: text_body,

--- a/spec/griddler/adapters/sendgrid_adapter_spec.rb
+++ b/spec/griddler/adapters/sendgrid_adapter_spec.rb
@@ -44,6 +44,19 @@ describe Griddler::Adapters::SendgridAdapter, '.normalize_params' do
     normalized_params[:to].should eq [default_params[:to]]
   end
 
+  it 'wraps cc in an array' do
+    normalized_params = normalize_params(default_params)
+
+    normalized_params[:cc].should eq [default_params[:cc]]
+  end
+
+  it 'returns an array even if cc is empty' do
+    params = default_params.merge(cc: nil)
+    normalized_params = normalize_params(params)
+
+    normalized_params[:cc].should eq []
+  end
+
   def normalize_params(params)
     Griddler::Adapters::SendgridAdapter.normalize_params(params)
   end
@@ -52,6 +65,7 @@ describe Griddler::Adapters::SendgridAdapter, '.normalize_params' do
     {
       text: 'hi',
       to: 'hi@example.com',
+      cc: 'cc@example.com',
       from: 'there@example.com',
     }
   end

--- a/spec/griddler/configuration_spec.rb
+++ b/spec/griddler/configuration_spec.rb
@@ -9,6 +9,7 @@ describe Griddler::Configuration do
     it 'provides defaults' do
       Griddler.configuration.processor_class.should eq(EmailProcessor)
       Griddler.configuration.to.should eq(:hash)
+      Griddler.configuration.cc.should eq(:email)
       Griddler.configuration.from.should eq(:email)
       Griddler.configuration.reply_delimiter.should eq('Reply ABOVE THIS LINE')
       Griddler.configuration.email_service.should eq(Griddler::Adapters::SendgridAdapter)
@@ -35,6 +36,14 @@ describe Griddler::Configuration do
       Griddler.configure do |config|
         config.to = :token
       end
+    end
+
+    it 'stores a cc' do
+      Griddler.configure do |config|
+        config.cc = :full
+      end
+
+      Griddler.configuration.cc.should eq :full
     end
 
     it 'stores a from' do

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -475,24 +475,17 @@ end
 describe Griddler::Email, 'extracting email addresses from CC field' do
   before do
     @address = 'bob@example.com'
-    @headers = 'Cc: reply@example.com, foo <foo@example.com>'
+    @cc = 'Charles Conway <charles+123@example.com>'
   end
 
-  it 'extracts the cc addresses as Array' do
-    email = Griddler::Email.new(to: [@address], from: @address, headers: @headers).process
-    email.cc.class.should eq Array
+  it 'uses the cc fromt he adapter' do
+    email = Griddler::Email.new(to: [@address], from: @address, cc: [@cc], headers: @headers).process
+    email.cc.should eq ['charles+123@example.com']
   end
-
 
   it 'returns an empty array when no CC address is added' do
     email = Griddler::Email.new(to: [@address], from: @address).process
     email.cc.should be_empty
-  end
-
-  it 'parses multiple emails' do
-    email = Griddler::Email.new(to: [@address], from: @address, headers: @headers).process
-    email.cc.should include('reply@example.com')
-    email.cc.should include('foo@example.com')
   end
 end
 


### PR DESCRIPTION
If the adapter doesn't pass along a `to` then it falls back to parsing the headers passed along from the adapter. 

This breaks the current cc a bit in that the default configuration is `:hash` and the current one behaves like `:email`. I think this is maybe ok in that people using the current behavior can update their config to use `:email` and not have any more problems. 

/cc @sauron @natew
