### PR TITLE
Better parsing of emails form iOS Mail client

### DIFF
--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -82,8 +82,8 @@ module Griddler::EmailParser
       reply_delimeter_regex,
       /^\s*[-]+\s*Original Message\s*[-]+\s*$/i,
       /^\s*--\s*$/,
+      /^\s*\>?\s*On.*\r?\n?\s*.*\s*wrote:$/,
       /On.*wrote:/,
-      /^\s*On.*\r?\n?\s*.*\s*wrote:$/,
       /From:.*$/i,
       /^\s*\d{4}\/\d{1,2}\/\d{1,2}\s.*\s<.*>?$/i
     ]

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -107,6 +107,22 @@ describe Griddler::Email, 'body formatting' do
     body_from_email(:text, body).should eq 'Hello.'
   end
 
+  it 'handles "> On [date] [soandso] <email@example.com> wrote:" format' do
+    body = <<-EOF.strip_heredoc
+      Hello.
+
+      > On 10 janv. 2014, at 18:00, Tristan <email@example.com> wrote:
+      > Check out this report.
+      >
+      > It's pretty cool.
+      >
+      > Thanks, Tristan
+      > 
+    EOF
+
+    body_from_email(:text, body).should eq 'Hello.'
+  end
+
   it 'handles "From: email@email.com" format' do
     body = <<-EOF
       Hello.


### PR DESCRIPTION
iOS Mail client add a ">" before "On [date] [soandso] email@example.com wrote:" string

This commit updates the `regex_split_points` in `Griddler::EmailParser` to take this into account
