### PR TITLE
Fixed NoMethodError when email object receives nil for text.

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -87,7 +87,7 @@ module Griddler
     end
 
     def clean_invalid_utf8_bytes(text)
-      if !text.valid_encoding?
+      if !text.nil? && !text.valid_encoding?
         text = text
           .force_encoding('ISO-8859-1')
           .encode('UTF-8')

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -389,6 +389,12 @@ describe Griddler::Email, 'multipart emails' do
     )
     email.raw_body.should eq '<b>hello there</b>'
   end
+  
+  it 'handles nil text on email initialization' do
+    expect { email = email_with_params(
+      text: nil
+    ) }.not_to raise_error #NoMethodError
+  end
 
   def email_with_params(params)
     params = {


### PR DESCRIPTION
Upon instantiation of the Email object from Mandrill `text` was nil. This nil text was passed down to the `clean_invalid_utf8_bytes` method where the `!text.valid_encoding?` method was called on the nil object.

I am not familiar enough with the process to know if the text from an adapter should never be nil to begin with. This may reflect a larger underlying issue with how Mandrill emails are processed.
