### PR TITLE
Fix for ruby version >2

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -42,7 +42,7 @@ module Griddler
     end
 
     def recipients(type=:to)
-      [params[type]].flatten.compact.map { |recipient| extract_address(recipient, config.send(type)) }
+      Array.wrap(params[type]).compact.map { |recipient| extract_address(recipient, config.send(type)) }
     end
 
     def extract_address(address, type)

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -611,5 +611,14 @@ describe Griddler::Email, 'with custom configuration' do
 
       email.to.should eq recipients
     end
+    
+    it 'includes no recipients' do
+      params = {from: 'ralph@example.com', text: 'hi guys' }
+      Griddler.configuration.stub(to: :full)
+
+      email = Griddler::Email.new(params).process
+      email.to.should eq []
+    end
+    
   end
 end


### PR DESCRIPTION
String#to_a is not working in Ruby >2
