### PR TITLE
Update Travis config to match supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,13 @@
 language: ruby
 rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
+  - 2.0
+  - 2.1
 
 env:
-  - "RAILS_VERSION=3.2"
-  - "RAILS_VERSION=4.0"
+  - "RAILS_VERSION=4-0-stable"
+  - "RAILS_VERSION=4-1-stable"
   - "RAILS_VERSION=master"
 
 matrix:
   allow_failures:
     - env: "RAILS_VERSION=master"
-  exclude:
-    - rvm: 1.9.2
-      env: "RAILS_VERSION=4.0"
-    - rvm: 1.9.2
-      env: "RAILS_VERSION=master"


### PR DESCRIPTION
1. Drop support for Ruby < 2.0
   (https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/)
2. Drop support for Rails < 4 (http://rubyonrails.org/security)
3. Test against only stable versions of the 4.0.\* and 4.1.\* versions of
   Rails and master
