### PR TITLE
Adapters can register themselves

### DIFF
--- a/lib/griddler.rb
+++ b/lib/griddler.rb
@@ -6,6 +6,7 @@ require 'griddler/email'
 require 'griddler/email_parser'
 require 'griddler/configuration'
 require 'griddler/route_extensions'
+require 'griddler/adapter_registry'
 require 'griddler/adapters/sendgrid_adapter'
 require 'griddler/adapters/cloudmailin_adapter'
 require 'griddler/adapters/postmark_adapter'
@@ -13,4 +14,13 @@ require 'griddler/adapters/mandrill_adapter'
 require 'griddler/adapters/mailgun_adapter'
 
 module Griddler
+  def self.adapter_registry
+    @adapter_registry ||= AdapterRegistry.new
+  end
 end
+
+Griddler.adapter_registry.register(:sendgrid, Griddler::Adapters::SendgridAdapter)
+Griddler.adapter_registry.register(:cloudmailin, Griddler::Adapters::CloudmailinAdapter)
+Griddler.adapter_registry.register(:postmark, Griddler::Adapters::PostmarkAdapter)
+Griddler.adapter_registry.register(:mandrill, Griddler::Adapters::MandrillAdapter)
+Griddler.adapter_registry.register(:mailgun, Griddler::Adapters::MailgunAdapter)

--- a/lib/griddler/adapter_registry.rb
+++ b/lib/griddler/adapter_registry.rb
@@ -1,0 +1,24 @@
+module Griddler
+  class AdapterRegistry
+    DEFAULT_ADAPTER = :sendgrid
+
+    def initialize
+      @registry = {}
+    end
+
+    def register(adapter_name, adapter_class)
+      if adapter_name == DEFAULT_ADAPTER
+        @registry[:default] = adapter_class
+      end
+      @registry[adapter_name] = adapter_class
+    end
+
+    def [](adapter_name)
+      @registry[adapter_name]
+    end
+
+    def fetch(key, &block)
+      @registry.fetch(key, &block)
+    end
+  end
+end

--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -65,27 +65,11 @@ module Griddler
     end
 
     def email_service
-      @email_service_adapter ||= adapter_class[:sendgrid]
+      @email_service_adapter ||= Griddler.adapter_registry[:sendgrid]
     end
 
     def email_service=(new_email_service)
-      if new_email_service == :default
-        new_email_service = :sendgrid
-      end
-
-      @email_service_adapter = adapter_class.fetch(new_email_service) { raise Griddler::Errors::EmailServiceAdapterNotFound }
-    end
-
-    private
-
-    def adapter_class
-      {
-        sendgrid: Griddler::Adapters::SendgridAdapter,
-        cloudmailin: Griddler::Adapters::CloudmailinAdapter,
-        postmark: Griddler::Adapters::PostmarkAdapter,
-        mandrill: Griddler::Adapters::MandrillAdapter,
-        mailgun: Griddler::Adapters::MailgunAdapter
-      }
+      @email_service_adapter = Griddler.adapter_registry.fetch(new_email_service) { raise Griddler::Errors::EmailServiceAdapterNotFound }
     end
   end
 end

--- a/spec/griddler/adapter_registry_spec.rb
+++ b/spec/griddler/adapter_registry_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe Griddler::AdapterRegistry do
+  it 'it is exposed by Griddler' do
+    Griddler.adapter_registry.should be_a Griddler::AdapterRegistry
+  end
+
+  it 'can register adapters' do
+    adapter_registry = Griddler::AdapterRegistry.new
+
+    adapter_registry.register(:foo, adapter)
+
+    adapter_registry[:foo].should eq(adapter)
+  end
+
+  it 'can fetch like a hash' do
+    adapter_registry = Griddler::AdapterRegistry.new
+
+    result = adapter_registry.fetch(:non_existent) { 'exists' }
+
+    result.should eq 'exists'
+  end
+
+  it 'maps :default to :sendgrid' do
+    adapter_registry = Griddler::AdapterRegistry.new
+
+    adapter_registry.register(:sendgrid, adapter)
+
+    adapter_registry[:default].should eq(adapter)
+  end
+
+  def adapter
+    @adapter ||= Class.new
+  end
+end


### PR DESCRIPTION
This adds just the adapter registry, instead of the registry AND `griddler-sendgrid`.
