### PR TITLE
Test against different Rails version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,13 @@ rvm:
   - 2.1
 
 env:
-  - "RAILS_VERSION=4-0-stable"
-  - "RAILS_VERSION=4-1-stable"
-  - "RAILS_VERSION=master"
+  - "RAILS_BRANCH=4-0-stable"
+  - "RAILS_BRANCH=4-1-stable"
+  - "RAILS_BRANCH=master"
 
 matrix:
   allow_failures:
-    - env: "RAILS_VERSION=master"
+    - env: "RAILS_BRANCH=master"
 
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@ source "http://rubygems.org"
 
 gemspec
 
-if ENV["RAILS_VERSION"]
-  gem "rails", github: "rails/rails", branch: ENV["RAILS_VERSION"]
+if ENV["RAILS_BRANCH"]
+  gem "rails", github: "rails/rails", branch: ENV["RAILS_BRANCH"]
 else
   gem "rails", "~> 4.0.0"
 end


### PR DESCRIPTION
`ENV["RAILS_VERSION"]` was being set to Rails branch names (like `4-0-stable`), but was being used as a normal version constraint. This led to declarations like:

```
gem "rails", "~> 4-0-stable.0"
# or
gem "rails", "~> 4-1-stable.0"
```

Both of these were translated by Rubygems into "get the latest version", so they both tested against the same version of Rails, currently 4.1.2.rc1.

You can see this here: https://travis-ci.org/thoughtbot/griddler/builds/26420309

This commit makes it so we always interpret `ENV["RAILS_VERSION"]` as a branch name. We still fall back to testing against Rails 4.0.0 if the environment variable is unset.
