### PR TITLE
Convert specs to RSpec 3.0.2 syntax with Transpec

### DIFF
--- a/lib/griddler/testing.rb
+++ b/lib/griddler/testing.rb
@@ -44,14 +44,14 @@ shared_examples_for 'Griddler adapter' do |adapter, service_params|
     Array.wrap(normalized_params).each do |params|
       email = Griddler::Email.new(params)
 
-      email.to.should eq([{
+      expect(email.to).to eq([{
         token: 'hi',
         host: 'example.com',
         full: 'Hello World <hi@example.com>',
         email: 'hi@example.com',
         name: 'Hello World',
       }])
-      email.cc.should eq [{
+      expect(email.cc).to eq [{
         token: 'emily',
         host: 'example.com',
         email: 'emily@example.com',
@@ -81,8 +81,8 @@ RSpec::Matchers.define :be_normalized_to do |expected|
   match do |actual|
     expected.each do |k, v|
       case v
-      when Regexp then actual[k].should =~ v
-      else actual[k].should === v
+      when Regexp then expect(actual[k]).to =~ v
+      else expect(actual[k]).to === v
       end
     end
   end

--- a/spec/controllers/griddler/emails_controller_spec.rb
+++ b/spec/controllers/griddler/emails_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Griddler::EmailsController do
+describe Griddler::EmailsController, :type => :controller do
   before(:each) do
     fake_adapter = double(normalize_params: normalized_params)
     Griddler.adapter_registry.register(:one_that_works, fake_adapter)
@@ -11,12 +11,12 @@ describe Griddler::EmailsController do
     it 'is successful' do
       post :create, email_params
 
-      response.should be_success
+      expect(response).to be_success
     end
 
     it 'creates a new Griddler::Email with the given params' do
       email = double
-      Griddler::Email.should_receive(:new).
+      expect(Griddler::Email).to receive(:new).
         with(hash_including(to: ['tb@example.com'])).
         and_return(email)
 
@@ -25,18 +25,18 @@ describe Griddler::EmailsController do
 
     it 'calls process on the custom processor class' do
       my_handler = double(process: nil)
-      my_handler.should_receive(:new).and_return(my_handler)
-      Griddler.configuration.stub(processor_class: my_handler)
+      expect(my_handler).to receive(:new).and_return(my_handler)
+      allow(Griddler.configuration).to receive_messages(processor_class: my_handler)
 
       post :create, email_params
     end
 
     it 'calls the custom processor method on the processor class' do
-      Griddler.configuration.stub(processor_method: :perform)
+      allow(Griddler.configuration).to receive_messages(processor_method: :perform)
       fake_processor = double(perform: nil)
 
-      EmailProcessor.should_receive(:new).and_return(fake_processor)
-      fake_processor.should_receive(:perform)
+      expect(EmailProcessor).to receive(:new).and_return(fake_processor)
+      expect(fake_processor).to receive(:perform)
 
       post :create, email_params
     end

--- a/spec/griddler/adapter_registry_spec.rb
+++ b/spec/griddler/adapter_registry_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Griddler::AdapterRegistry do
   it 'it is exposed by Griddler' do
-    Griddler.adapter_registry.should be_a Griddler::AdapterRegistry
+    expect(Griddler.adapter_registry).to be_a Griddler::AdapterRegistry
   end
 
   it 'can register adapters' do
@@ -10,7 +10,7 @@ describe Griddler::AdapterRegistry do
 
     adapter_registry.register(:foo, adapter)
 
-    adapter_registry[:foo].should eq(adapter)
+    expect(adapter_registry[:foo]).to eq(adapter)
   end
 
   it 'can fetch like a hash' do
@@ -18,7 +18,7 @@ describe Griddler::AdapterRegistry do
 
     result = adapter_registry.fetch(:non_existent) { 'exists' }
 
-    result.should eq 'exists'
+    expect(result).to eq 'exists'
   end
 
   it 'maps :default to :sendgrid' do
@@ -26,7 +26,7 @@ describe Griddler::AdapterRegistry do
 
     adapter_registry.register(:sendgrid, adapter)
 
-    adapter_registry[:default].should eq(adapter)
+    expect(adapter_registry[:default]).to eq(adapter)
   end
 
   def adapter

--- a/spec/griddler/configuration_spec.rb
+++ b/spec/griddler/configuration_spec.rb
@@ -7,14 +7,14 @@ describe Griddler::Configuration do
     end
 
     it 'provides defaults' do
-      Griddler.configuration.processor_class.should eq(EmailProcessor)
-      Griddler.configuration.reply_delimiter.should eq('Reply ABOVE THIS LINE')
-      Griddler.configuration.email_service.should eq(:test_adapter)
-      Griddler.configuration.processor_method.should eq(:process)
+      expect(Griddler.configuration.processor_class).to eq(EmailProcessor)
+      expect(Griddler.configuration.reply_delimiter).to eq('Reply ABOVE THIS LINE')
+      expect(Griddler.configuration.email_service).to eq(:test_adapter)
+      expect(Griddler.configuration.processor_method).to eq(:process)
     end
 
     it 'raises a helpful error if EmailProcessor is undefined' do
-      Kernel.stub(const_defined?: false)
+      allow(Kernel).to receive_messages(const_defined?: false)
 
       expect { Griddler.configuration.processor_class }.to raise_error(NameError, %r{https://github\.com/thoughtbot/griddler#defaults})
     end
@@ -32,7 +32,7 @@ describe Griddler::Configuration do
         config.processor_class = dummy_processor
       end
 
-      Griddler.configuration.processor_class.should eq dummy_processor
+      expect(Griddler.configuration.processor_class).to eq dummy_processor
     end
 
     it 'stores a processor_method' do
@@ -40,16 +40,16 @@ describe Griddler::Configuration do
         config.processor_method = :perform
       end
 
-      Griddler.configuration.processor_method.should eq(:perform)
+      expect(Griddler.configuration.processor_method).to eq(:perform)
     end
 
     it 'sets and stores an email_service' do
-      Griddler.should_receive(:adapter_registry).and_return(double(fetch: :configured_adapter))
+      expect(Griddler).to receive(:adapter_registry).and_return(double(fetch: :configured_adapter))
       Griddler.configure do |config|
         config.email_service = :another_adapter
       end
 
-      Griddler.configuration.email_service.should eq(:configured_adapter)
+      expect(Griddler.configuration.email_service).to eq(:configured_adapter)
     end
 
     it 'accepts a :default symbol and uses sendgrid' do
@@ -57,7 +57,7 @@ describe Griddler::Configuration do
         c.email_service = :default
       end
 
-      Griddler.configuration.email_service.should eq(:test_adapter)
+      expect(Griddler.configuration.email_service).to eq(:test_adapter)
     end
 
     it 'raises an error when setting a non-existent email service adapter' do
@@ -67,7 +67,7 @@ describe Griddler::Configuration do
         end
       end
 
-      config.should raise_error(Griddler::Errors::EmailServiceAdapterNotFound)
+      expect(config).to raise_error(Griddler::Errors::EmailServiceAdapterNotFound)
     end
   end
 end

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -9,7 +9,7 @@ describe Griddler::Email, 'body formatting' do
       <p>Hello.</p><span>Reply ABOVE THIS LINE</span><p>original message</p>
     EOF
 
-    body_from_email(html: body).should eq 'Hello.'
+    expect(body_from_email(html: body)).to eq 'Hello.'
   end
 
   it 'uses the html field and sanitizes it when text param is empty' do
@@ -17,31 +17,31 @@ describe Griddler::Email, 'body formatting' do
       <p>Hello.</p><span>Reply ABOVE THIS LINE</span><p>original message</p>
     EOF
 
-    body_from_email(html: body, text: '').should eq 'Hello.'
+    expect(body_from_email(html: body, text: '')).to eq 'Hello.'
   end
 
   it 'handles invalid utf-8 bytes in html' do
-    body_from_email(html: "Hell\xC0.").should eq 'HellÀ.'
+    expect(body_from_email(html: "Hell\xC0.")).to eq 'HellÀ.'
   end
 
   it 'handles invalid utf-8 bytes in text' do
-    body_from_email(text: "Hell\xF6.").should eq 'Hellö.'
+    expect(body_from_email(text: "Hell\xF6.")).to eq 'Hellö.'
   end
 
   it 'handles valid utf-8 bytes in html' do
-    body_from_email(html: "Hell\xF1.").should eq 'Hellñ.'
+    expect(body_from_email(html: "Hell\xF1.")).to eq 'Hellñ.'
   end
 
   it 'handles valid utf-8 bytes in text' do
-    body_from_email(text: "Hell\xF2.").should eq 'Hellò.'
+    expect(body_from_email(text: "Hell\xF2.")).to eq 'Hellò.'
   end
 
   it 'handles valid utf-8 char in html' do
-    body_from_email(html: 'Hellö.').should eq 'Hellö.'
+    expect(body_from_email(html: 'Hellö.')).to eq 'Hellö.'
   end
 
   it 'handles valid utf-8 char in text' do
-    body_from_email(text: 'Hellö.').should eq 'Hellö.'
+    expect(body_from_email(text: 'Hellö.')).to eq 'Hellö.'
   end
 
   it 'does not remove invalid utf-8 bytes if charset is set' do
@@ -53,7 +53,7 @@ describe Griddler::Email, 'body formatting' do
       text: 'iso-8859-1'
     }
 
-    body_from_email({ text: 'Helló.' }, charsets).should eq 'Helló.'
+    expect(body_from_email({ text: 'Helló.' }, charsets)).to eq 'Helló.'
   end
 
   it 'handles everything on one line' do
@@ -61,7 +61,7 @@ describe Griddler::Email, 'body formatting' do
       Hello. On 01/12/13, Tristan <email@example.com> wrote: Reply ABOVE THIS LINE or visit your website to respond.
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'handles "On [date] [soandso] wrote:" format' do
@@ -76,7 +76,7 @@ describe Griddler::Email, 'body formatting' do
       > Thanks, Tristan
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'handles "On [date] [soandso] <email@example.com> wrote:" format' do
@@ -91,7 +91,7 @@ describe Griddler::Email, 'body formatting' do
       > Thanks, Tristan
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'handles "On [date] [soandso]\n<email@example.com> wrote:" format' do
@@ -106,7 +106,7 @@ describe Griddler::Email, 'body formatting' do
       > Thanks, Tristan
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'handles "> On [date] [soandso] <email@example.com> wrote:" format' do
@@ -122,7 +122,7 @@ describe Griddler::Email, 'body formatting' do
       >
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'handles "From: email@email.com" format' do
@@ -136,7 +136,7 @@ describe Griddler::Email, 'body formatting' do
       Check out this report!
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'handles "-----Original Message-----" format' do
@@ -151,7 +151,7 @@ describe Griddler::Email, 'body formatting' do
       Check out this report!
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'handles "-----Original Message-----" format without a preceding body' do
@@ -164,7 +164,7 @@ describe Griddler::Email, 'body formatting' do
       Check out this report!
     EOF
 
-    body_from_email(text: body).should eq ''
+    expect(body_from_email(text: body)).to eq ''
   end
 
   it 'handles "-----Original message-----" case insensitively' do
@@ -179,7 +179,7 @@ describe Griddler::Email, 'body formatting' do
       Check out this report!
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'handles "-----Original message-----" case insensitively without a preceding body' do
@@ -192,7 +192,7 @@ describe Griddler::Email, 'body formatting' do
       Check out this report!
     EOF
 
-    body_from_email(text: body).should eq ''
+    expect(body_from_email(text: body)).to eq ''
   end
 
   it 'handles "[date] [soandso] <email@example>" format' do
@@ -205,7 +205,7 @@ describe Griddler::Email, 'body formatting' do
       > Thanks, Tristan
     EOF
 
-    body_from_email(text: body).should eq ''
+    expect(body_from_email(text: body)).to eq ''
   end
 
   it 'handles "Reply ABOVE THIS LINE" format' do
@@ -217,7 +217,7 @@ describe Griddler::Email, 'body formatting' do
       Hey!
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'removes > in "> Reply ABOVE THIS LINE" ' do
@@ -227,7 +227,7 @@ describe Griddler::Email, 'body formatting' do
       > Reply ABOVE THIS LINE
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'removes any non-content things above Reply ABOVE THIS LINE' do
@@ -241,7 +241,7 @@ describe Griddler::Email, 'body formatting' do
       Hey!
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'removes any iphone things above Reply ABOVE THIS LINE' do
@@ -255,7 +255,7 @@ describe Griddler::Email, 'body formatting' do
       Hey!
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'should remove any signature above Reply ABOVE THIS LINE' do
@@ -272,7 +272,7 @@ describe Griddler::Email, 'body formatting' do
       > Hey!
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'should remove any signature without space above Reply ABOVE THIS LINE' do
@@ -289,7 +289,7 @@ describe Griddler::Email, 'body formatting' do
       > Hey!
     EOF
 
-    body_from_email(text: body).should eq 'Hello.'
+    expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
   it 'properly handles a json charsets' do
@@ -314,27 +314,27 @@ describe Griddler::Email, 'body formatting' do
       text: 'utf-8'
     }
 
-    body_from_email({ text: body }, charsets).should eq 'Hello.'
+    expect(body_from_email({ text: body }, charsets)).to eq 'Hello.'
   end
 
   it 'should preserve empty lines' do
     body = "Hello.\n\nWhat's up?"
 
-    body_from_email(text: body).should eq body
+    expect(body_from_email(text: body)).to eq body
   end
 
   it 'preserves blockquotes' do
     body = "> Hello.\n\n>another line"
 
-    body_from_email(text: body).should eq body
+    expect(body_from_email(text: body)).to eq body
   end
 
   it 'handles empty body values' do
-    body_from_email(text: '').should eq ''
+    expect(body_from_email(text: '')).to eq ''
   end
 
   it 'handles missing body keys' do
-    body_from_email(text: nil).should eq ''
+    expect(body_from_email(text: nil)).to eq ''
   end
 
   def body_from_email(raw_body, charsets = {})
@@ -365,8 +365,8 @@ describe Griddler::Email, 'multipart emails' do
       html: '<b>hello there</b>',
       text: 'hello there'
     )
-    email.raw_html.should eq '<b>hello there</b>'
-    email.raw_text.should eq 'hello there'
+    expect(email.raw_html).to eq '<b>hello there</b>'
+    expect(email.raw_text).to eq 'hello there'
   end
 
   it 'uses text as raw_body if both text and html are present' do
@@ -374,21 +374,21 @@ describe Griddler::Email, 'multipart emails' do
       html: '<b>hello there</b>',
       text: 'hello there'
     )
-    email.raw_body.should eq 'hello there'
+    expect(email.raw_body).to eq 'hello there'
   end
 
   it 'uses text as raw_body' do
     email = email_with_params(
       text: 'hello there'
     )
-    email.raw_body.should eq 'hello there'
+    expect(email.raw_body).to eq 'hello there'
   end
 
   it 'uses html as raw_body if text is not present' do
     email = email_with_params(
       html: '<b>hello there</b>'
     )
-    email.raw_body.should eq '<b>hello there</b>'
+    expect(email.raw_body).to eq '<b>hello there</b>'
   end
 
   it 'uses html as raw_body if text is empty' do
@@ -396,7 +396,7 @@ describe Griddler::Email, 'multipart emails' do
       html: '<b>hello there</b>',
       text: ''
     )
-    email.raw_body.should eq '<b>hello there</b>'
+    expect(email.raw_body).to eq '<b>hello there</b>'
   end
 
   def email_with_params(params)
@@ -416,17 +416,17 @@ describe Griddler::Email, 'extracting email headers' do
     header = "#{header_name}: #{header_value}"
 
     headers = header_from_email(header)
-    headers[header_name].should eq header_value
+    expect(headers[header_name]).to eq header_value
   end
 
   it 'handles no matched headers' do
     headers = header_from_email('')
-    headers.should eq({})
+    expect(headers).to eq({})
   end
 
   it 'handles nil headers' do
     headers = header_from_email(nil)
-    headers.should eq({})
+    expect(headers).to eq({})
   end
 
   def header_from_email(header)
@@ -459,7 +459,7 @@ describe Griddler::Email, 'extracting email addresses' do
       to: [@full_address],
       from: @full_address,
     )
-    email.to.should eq [@address_components.merge(name: 'Bob')]
+    expect(email.to).to eq [@address_components.merge(name: 'Bob')]
   end
 
   it 'handles normal e-mail address' do
@@ -472,16 +472,16 @@ describe Griddler::Email, 'extracting email addresses' do
       full: @address_components[:email],
       name: nil,
     )
-    email.to.should eq [expected]
-    email.from.should eq @address_components
+    expect(email.to).to eq [expected]
+    expect(email.from).to eq @address_components
   end
 
   it 'handles new lines' do
     email = Griddler::Email.new(text: 'hi', to: ["#{@full_address}\n"],
       from: "#{@full_address}\n")
     expected = @address_components.merge(full: "#{@full_address}\n")
-    email.to.should eq [expected]
-    email.from.should eq expected
+    expect(email.to).to eq [expected]
+    expect(email.from).to eq expected
   end
 
   it 'handles angle brackets around address' do
@@ -493,8 +493,8 @@ describe Griddler::Email, 'extracting email addresses' do
     expected = @address_components.merge(
       full: "<#{@address_components[:email]}>",
       name: nil)
-    email.to.should eq [expected]
-    email.from.should eq expected
+    expect(email.to).to eq [expected]
+    expect(email.from).to eq expected
   end
 
   it 'handles name and angle brackets around address' do
@@ -503,8 +503,8 @@ describe Griddler::Email, 'extracting email addresses' do
       to: [@full_address],
       from: @full_address
     )
-    email.to.should eq [@address_components]
-    email.from.should eq @address_components
+    expect(email.to).to eq [@address_components]
+    expect(email.from).to eq @address_components
   end
 
   it 'handles multiple e-mails, with priority to the bracketed' do
@@ -518,8 +518,8 @@ describe Griddler::Email, 'extracting email addresses' do
       name: 'fake@example.com'
     )
 
-    email.to.should eq [expected]
-    email.from.should eq expected
+    expect(email.to).to eq [expected]
+    expect(email.from).to eq expected
   end
 end
 
@@ -531,7 +531,7 @@ describe Griddler::Email, 'extracting email addresses from CC field' do
 
   it 'uses the cc from the adapter' do
     email = Griddler::Email.new(to: [@address], from: @address, cc: [@cc], headers: @headers)
-    email.cc.should eq [{
+    expect(email.cc).to eq [{
       token: 'charles+123',
       host: 'example.com',
       email: 'charles+123@example.com',
@@ -542,7 +542,7 @@ describe Griddler::Email, 'extracting email addresses from CC field' do
 
   it 'returns an empty array when no CC address is added' do
     email = Griddler::Email.new(to: [@address], from: @address)
-    email.cc.should be_empty
+    expect(email.cc).to be_empty
   end
 end
 
@@ -568,10 +568,10 @@ describe Griddler::Email, 'with custom configuration' do
 
   describe 'accepts and works with a string reply delimiter' do
     it 'does not split on Reply ABOVE THIS LINE' do
-      Griddler.configuration.stub(reply_delimiter: 'Stuff and things')
+      allow(Griddler.configuration).to receive_messages(reply_delimiter: 'Stuff and things')
       email = Griddler::Email.new(params)
 
-      email.body.should eq params[:text]
+      expect(email.body).to eq params[:text]
     end
 
     it 'splits at custom delimeter' do
@@ -583,15 +583,15 @@ describe Griddler::Email, 'with custom configuration' do
         wut
       EOS
 
-      Griddler.configuration.stub(reply_delimiter: '-- reply above --')
+      allow(Griddler.configuration).to receive_messages(reply_delimiter: '-- reply above --')
       email = Griddler::Email.new(params)
-      email.body.should eq 'trolololo'
+      expect(email.body).to eq 'trolololo'
     end
   end
 
   describe 'accepts and works with an array of reply delimiters' do
     before do
-      Griddler.configuration.stub(reply_delimiter: ['-- old reply above --', '-- new reply above --'])
+      allow(Griddler.configuration).to receive_messages(reply_delimiter: ['-- old reply above --', '-- new reply above --'])
     end
 
     it 'splits with old delimiter' do
@@ -604,7 +604,7 @@ describe Griddler::Email, 'with custom configuration' do
       EOS
 
       email = Griddler::Email.new(params)
-      email.body.should eq 'Hey, split me with the old one!'
+      expect(email.body).to eq 'Hey, split me with the old one!'
     end
 
     it 'splits with the new delimiter' do
@@ -617,7 +617,7 @@ describe Griddler::Email, 'with custom configuration' do
       EOS
 
       email = Griddler::Email.new(params)
-      email.body.should eq 'Hey, split me with the new one!'
+      expect(email.body).to eq 'Hey, split me with the new one!'
     end
   end
 
@@ -627,7 +627,7 @@ describe Griddler::Email, 'with custom configuration' do
 This is the real text\r\n\r\n\r\nOn Fri, Mar 21, 2014 at 3:11 PM, Someone <\r\nsomeone@example.com> wrote:\r\n\r\n>  -- REPLY ABOVE THIS LINE --\r\n>\r\n> The Old message!\r\n>\r\n> Another line! *\r\n>\n
       EOS
       email = Griddler::Email.new(params)
-      email.body.should eq 'This is the real text'
+      expect(email.body).to eq 'This is the real text'
     end
   end
 
@@ -638,7 +638,7 @@ This is the real text\r\n\r\n\r\nOn Fri, Mar 21, 2014 at 3:11 PM, Someone <\r\ns
 
       email = Griddler::Email.new(params)
 
-      email.to.map { |to| to[:full] }.should eq recipients
+      expect(email.to.map { |to| to[:full] }).to eq recipients
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,11 +9,11 @@ RSpec.configure do |config|
   config.order = "random"
 
   config.expect_with :rspec do |c|
-    c.syntax = [:expect, :should]
+    c.syntax = :expect
   end
 
   config.mock_with :rspec do |c|
-    c.syntax = :should
+    c.syntax = :expect
   end
 
   config.before :each do


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec
- 73 conversions
  from: obj.should
    to: expect(obj).to
