### PR TITLE
Allow email body paragraphs to begin with 'On'

### DIFF
--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -76,7 +76,7 @@ module Griddler::EmailParser
       reply_delimeter_regex,
       /^\s*[-]+\s*Original Message\s*[-]+\s*$/i,
       /^\s*--\s*$/,
-      /^\s*\>?\s*On.*\r?\n?\s*.*\s*wrote:\r?\n?$/,
+      /^\s*\>?\s*On.*\r?\n?.*wrote:\r?\n?$/,
       /On.*wrote:/,
       /From:.*$/i,
       /^\s*\d{4}\/\d{1,2}\/\d{1,2}\s.*\s<.*>?$/i

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -292,6 +292,19 @@ describe Griddler::Email, 'body formatting' do
     expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
+  it 'allows paragraphs to begin with "On"' do
+    body = <<-EOF
+      On the counter.
+
+      On Tue, Sep 30, 2014 at 9:13 PM Tristan <email@example.com> wrote:
+      > Where's that report?
+      >
+      > Thanks, Tristen
+    EOF
+
+    expect(body_from_email(text: body)).to eq 'On the counter.'
+  end
+
   it 'properly handles a json charsets' do
     body = <<-EOF
       Hello.


### PR DESCRIPTION
One of the `EmailParser` regex seems a bit greedy. I'm unable to begin paragraphs with the word 'On' because they get stripped out by the parser.

This body currently returns an empty string:

```
On the counter.

On Tue, Sep 30, 2014 at 9:13 PM Tristan <email@example.com> wrote:
> Where's that report?
>
> Thanks, Tristen
```

The change in this PR fixes this, but makes is so that bodies like the example below would not get split:

```
Hello.

On Tue,

Sep 30, 2014 at 9:13 PM Tristan <email@example.com> wrote:
> Where's that report?
>
> Thanks, Tristen
```

We don't have a test for the example above, so I assume it's not important. I've never seen an email body with a blank line in the middle of "On...".

cc @r00k because he's interested in this fix.
