### PR TITLE
Update email factory in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ with the following sample factory:
 factory :email, class: OpenStruct do
   # Assumes Griddler.configure.to is :hash (default)
   to [{ full: 'to_user@email.com', email: 'to_user@email.com', token: 'to_user', host: 'email.com', name: nil }]
-  from 'user@email.com'
+  from({ token: 'from_user', host: 'email.com', email: 'from_email@email.com', full: 'From User <from_user@email.com>', name: 'From User' })
   subject 'email subject'
   body 'Hello!'
   attachments {[]}


### PR DESCRIPTION
`email.from` returns [a Hash](https://github.com/thoughtbot/griddler/blob/239fc554285c4d21fee71d9de79d88c4ebe4936e/lib/griddler/email_parser.rb#L18-L24), not a String.
