### PR TITLE
Setting bcc attribute if using the griddler-sendgrid adapter

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -3,7 +3,7 @@ require 'htmlentities'
 module Griddler
   class Email
     include ActionView::Helpers::SanitizeHelper
-    attr_reader :to, :from, :cc, :subject, :body, :raw_body, :raw_text, :raw_html,
+    attr_reader :to, :from, :cc, :bcc, :subject, :body, :raw_body, :raw_text, :raw_html,
       :headers, :raw_headers, :attachments
 
     def initialize(params)
@@ -21,6 +21,7 @@ module Griddler
       @headers = extract_headers
 
       @cc = recipients(:cc)
+      @bcc = recipients(:bcc)
 
       @raw_headers = params[:headers]
 

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -465,6 +465,14 @@ describe Griddler::Email, 'extracting email addresses' do
       name: 'Bob',
     }
     @full_address= @address_components[:full]
+    @bcc_address_components = {
+      full: 'Johny <johny@example.com>',
+      email: 'johny@example.com',
+      token: 'johny',
+      host: 'example.com',
+      name: 'Johny',
+    }
+    @full_bcc_address= @bcc_address_components[:full]
   end
 
   it 'extracts the name' do
@@ -479,7 +487,7 @@ describe Griddler::Email, 'extracting email addresses' do
     email = Griddler::Email.new(
       text: 'hi',
       to: [@address_components[:email]],
-      from: @full_address,
+      from: @full_address
     )
     expected = @address_components.merge(
       full: @address_components[:email],
@@ -487,6 +495,17 @@ describe Griddler::Email, 'extracting email addresses' do
     )
     expect(email.to).to eq [expected]
     expect(email.from).to eq @address_components
+
+  end
+
+  it 'returns the BCC email' do
+    email = Griddler::Email.new(
+        text: 'hi',
+        to: [@address_components[:email]],
+        from: @full_address,
+        bcc: [@full_bcc_address],
+    )
+    expect(email.bcc).to eq [@bcc_address_components]
   end
 
   it 'handles new lines' do


### PR DESCRIPTION
Created a pull request for the adapter change. In response to: https://github.com/thoughtbot/griddler/issues/168. Thanks!
