### PR TITLE
Fix ArgumentError for `be_normalized_to` matcher.

### DIFF
--- a/lib/griddler/testing.rb
+++ b/lib/griddler/testing.rb
@@ -81,8 +81,8 @@ RSpec::Matchers.define :be_normalized_to do |expected|
   match do |actual|
     expected.each do |k, v|
       case v
-      when Regexp then expect(actual[k]).to =~ v
-      else expect(actual[k]).to === v
+      when Regexp then expect(actual[k]).to match(v)
+      else expect(actual[k]).to eq(v)
       end
     end
   end


### PR DESCRIPTION
rspec will now throw errors when using operators with `#to`, so we need to use a matcher instead. I got the error when running the specs on the Postmark adapter (r38y/griddler-postmark@e0eb4eeab).

These are the rspec gems in my Gemfile.lock

```
    rspec (3.1.0)
      rspec-core (~> 3.1.0)
      rspec-expectations (~> 3.1.0)
      rspec-mocks (~> 3.1.0)
    rspec-core (3.1.7)
      rspec-support (~> 3.1.0)
    rspec-expectations (3.1.2)
      rspec-support (~> 3.1.0)
    rspec-mocks (3.1.3)
      rspec-support (~> 3.1.0)
    rspec-support (3.1.2)
  rspec
```

And this is the error I was getting:

```
ArgumentError:
  The expect syntax does not support operator matchers, so you must pass a matcher to `#to`.
```

When I point the adapter's Gemfile to my fork with this change, the error is gone.

I have no idea how else to "test" this other than "the error is no longer there", so if you have any idea I'll gladly update the PR.
