### PR TITLE
Allow hashes to be submitted as headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Griddler::Email attributes
 | `#raw_html`    | The raw html part of the body.
 | `#raw_body`    | The raw body information provided by the email service.
 | `#attachments` | An array of `File` objects containing any attachments.
-| `#headers`     | A hash of headers parsed by `Mail::Header`.
+| `#headers`     | A hash of headers parsed by `Mail::Header`, unless they are already formatted as a hash when received from the adapter in which case the original hash is returned.
 | `#raw_headers` | The raw headers included in the message.
 
 ### Email Addresses

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -40,6 +40,7 @@ module Griddler::EmailParser
   end
 
   def self.extract_headers(raw_headers)
+    return raw_headers if raw_headers.is_a?(Hash)
     header_fields = Mail::Header.new(raw_headers).fields
 
     header_fields.inject({}) do |header_hash, header_field|

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -40,7 +40,9 @@ module Griddler::EmailParser
   end
 
   def self.extract_headers(raw_headers)
-    return raw_headers if raw_headers.is_a?(Hash)
+    if raw_headers.is_a?(Hash)
+      return raw_headers
+    end
     header_fields = Mail::Header.new(raw_headers).fields
 
     header_fields.inject({}) do |header_hash, header_field|

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -432,6 +432,14 @@ describe Griddler::Email, 'extracting email headers' do
     expect(headers[header_name]).to eq header_value
   end
 
+  it 'handles a hash being submitted' do
+    header = {"X-Mailer" => "Airmail (271)",
+              "Mime-Version" => "1.0",
+              "Content-Type" => "multipart/alternative; boundary=\"546876a7_66334873_aa8\""}
+    headers = header_from_email(header)
+    expect(headers["X-Mailer"]).to eq("Airmail (271)")
+  end
+
   it 'handles no matched headers' do
     headers = header_from_email('')
     expect(headers).to eq({})

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -434,8 +434,8 @@ describe Griddler::Email, 'extracting email headers' do
 
   it 'handles a hash being submitted' do
     header = {
-              "X-Mailer" => "Airmail (271)",
-              "Mime-Version" => "1.0"
+                "X-Mailer" => "Airmail (271)",
+                "Mime-Version" => "1.0"
               }
     headers = header_from_email(header)
     expect(headers["X-Mailer"]).to eq("Airmail (271)")

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -433,9 +433,10 @@ describe Griddler::Email, 'extracting email headers' do
   end
 
   it 'handles a hash being submitted' do
-    header = {"X-Mailer" => "Airmail (271)",
-              "Mime-Version" => "1.0",
-              "Content-Type" => "multipart/alternative; boundary=\"546876a7_66334873_aa8\""}
+    header = {
+              "X-Mailer" => "Airmail (271)",
+              "Mime-Version" => "1.0"
+              }
     headers = header_from_email(header)
     expect(headers["X-Mailer"]).to eq("Airmail (271)")
   end


### PR DESCRIPTION
Hi!

Thanks for this awesome gem! I am finding it super useful. :-) I am pretty new to this whole thing, so please let me know if I have missed something or there is a much better way of doing this. 

Goal
-------
Allow hashes to be sent as headers from the adapter gems. 

Side Note
-------
I looked at the Mandrill, Sendgrid, PostMark gems and as far as I can see none of them submit header params.

Current Situation
-------
If a hash is submitted when it is processed by the Mail::Header class it will throw an exception. My logic is that if the headers are already formatted hashes, then they do not need to be processed by Mail::Header.

Tests
-------
I have added a test to confirm that hashes are dealt with correctly.

I look forward to your feedback.

Cheers
Matthew