### PR TITLE
Tell Jekyll to auto-compile SCSS for us

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ It's a Jekyll app running on GitHub pages.
 
 ## Local development
 
-Watch sass:
-
-    sass --watch stylesheets/main.scss:stylesheets/main.css
-
 Run Jekyll, watching for changes:
 
     jekyll serve -w

--- a/_config.yml
+++ b/_config.yml
@@ -10,3 +10,5 @@ url: "http://thoughtbot.com"
 markdown: kramdown
 permalink: pretty
 exclude: [CNAME, README.md]
+sass:
+  sass_dir: stylesheets

--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -1,3 +1,7 @@
+---
+# this ensures Jekyll reads the file to be transformed into CSS later
+# only main SCSS files contain this front matter, not partials.
+---
 @import "normalize";
 @import "bourbon/bourbon";
 @import "bitters/bitters";


### PR DESCRIPTION
Tell Jekyll to auto-compile SCSS for us

There's no more need for `sass --watch` since Jekyll does that for us now.

We need dummy front-matter in `main.scss` so Jekyll compiles it.

We need to tell Jekyll where to find partials (in `/stylesheets`) because it
defaults to `/_sass`.

Asset docs: http://jekyllrb.com/docs/assets/
