### PR TITLE
Only run Travis on master and PRs against master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
   - "RAILS_BRANCH=4-1-stable"
   - "RAILS_BRANCH=master"
 branches:
-  except:
-    - gh-pages
+  only:
+    - master
 matrix:
   allow_failures:
     - env: "RAILS_BRANCH=master"


### PR DESCRIPTION
Telling Travis to only run on the master branch will run it on the master branch and PRs against the master branch.

For example, it will not run against the gh-pages branch or PRs against the gh-pages branch.

Tag: #rails