### PR TITLE
Handle MS Outlook reply format split point

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ end
 | `reply_delimiter`  | The string searched for that will split your body.
 | `email_service`    | Tells Griddler which email service you are using. The supported email service options are `:sendgrid` (the default), `:cloudmailin` (expects multipart format), `:postmark`, `:mandrill` and `:mailgun`. You will also need to have an appropriate [adapter] gem included in your Gemfile.
 
-By default Griddler will look for a class named `EmailProcessor` with a method
-named `process`, taking in one argument, a `Griddler::Email` instance
-representing the incoming email.  For example, in `./lib/email_processor.rb`:
+By default Griddler will look for a class named `EmailProcessor`. The class is 
+initialized with a `Griddler::Email` instance representing the incoming
+email, and has a `process` method to actually process the email.
+For example, in `./lib/email_processor.rb`:
 
 ```ruby
 class EmailProcessor

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -78,7 +78,7 @@ module Griddler::EmailParser
       /^\s*--\s*$/,
       /^\s*\>?\s*On.*\r?\n?.*wrote:\r?\n?$/,
       /On.*wrote:/,
-      /From:.*$/i,
+      /\*?From:.*$/i,
       /^\s*\d{4}\/\d{1,2}\/\d{1,2}\s.*\s<.*>?$/i
     ]
   end

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -139,6 +139,20 @@ describe Griddler::Email, 'body formatting' do
     expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
+  it 'handles "*From:* email@email.com" format' do
+    body = <<-EOF
+      Hello.
+
+      *From:* bob@example.com
+      *Sent:* Today
+      *Subject:* Awesome report.
+
+      Check out this report!
+    EOF
+
+    expect(body_from_email(text: body)).to eq 'Hello.'
+  end
+
   it 'handles "-----Original Message-----" format' do
     body = <<-EOF
       Hello.


### PR DESCRIPTION
Microsoft Outlook (at least 2013) uses asterisks around the field names in plain text forwards/replies, e.g.:

```
*From:* bob@example.com
*Sent:* Today
*Subject:* Awesome report.
```

Currently, parsed email bodies from Outlook are ending with a couple blank lines and then a single asterisk. I updated the "From:" regex to allow an optional starting asterisk so now it parses correctly.