### PR TITLE
Handle MS Outlook reply format split point

### DIFF
--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -78,7 +78,7 @@ module Griddler::EmailParser
       /^\s*--\s*$/,
       /^\s*\>?\s*On.*\r?\n?.*wrote:\r?\n?$/,
       /On.*wrote:/,
-      /From:.*$/i,
+      /\*?From:.*$/i,
       /^\s*\d{4}\/\d{1,2}\/\d{1,2}\s.*\s<.*>?$/i
     ]
   end

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -139,6 +139,20 @@ describe Griddler::Email, 'body formatting' do
     expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
+  it 'handles "*From:* email@email.com" format' do
+    body = <<-EOF
+      Hello.
+
+      *From:* bob@example.com
+      *Sent:* Today
+      *Subject:* Awesome report.
+
+      Check out this report!
+    EOF
+
+    expect(body_from_email(text: body)).to eq 'Hello.'
+  end
+
   it 'handles "-----Original Message-----" format' do
     body = <<-EOF
       Hello.


### PR DESCRIPTION
Microsoft Outlook (at least 2013) uses asterisks around the field names in plain text forwards/replies, e.g.:

```
*From:* bob@example.com
*Sent:* Today
*Subject:* Awesome report.
```

Currently, parsed email bodies from Outlook are ending with a couple blank lines and then a single asterisk. I updated the "From:" regex to allow an optional starting asterisk so now it parses correctly.