### PR TITLE
Use Ruby unicode compatible regexes for UTF8 strings

### DIFF
--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -31,8 +31,8 @@ module Griddler::EmailParser
       remove_reply_portion(body)
         .split(/[\r]*\n/)
         .reject do |line|
-          line =~ /^\s+>/ ||
-            line =~ /^\s*Sent from my /
+          line =~ /^[[:space:]]+>/ ||
+            line =~ /^[[:space:]]*Sent from my /
         end.
         join("\n").
         strip
@@ -74,12 +74,12 @@ module Griddler::EmailParser
   def self.regex_split_points
     [
       reply_delimeter_regex,
-      /^\s*[-]+\s*Original Message\s*[-]+\s*$/i,
-      /^\s*--\s*$/,
-      /^\s*\>?\s*On.*\r?\n?.*wrote:\r?\n?$/,
+      /^[[:space:]]*[-]+[[:space:]]*Original Message[[:space:]]*[-]+[[:space:]]*$/i,
+      /^[[:space:]]*--[[:space:]]*$/,
+      /^[[:space:]]*\>?[[:space:]]*On.*\r?\n?.*wrote:\r?\n?$/,
       /On.*wrote:/,
       /\*?From:.*$/i,
-      /^\s*\d{4}\/\d{1,2}\/\d{1,2}\s.*\s<.*>?$/i
+      /^[[:space:]]*\d{4}\/\d{1,2}\/\d{1,2}[[:space:]].*[[:space:]]<.*>?$/i
     ]
   end
 

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -289,6 +289,19 @@ describe Griddler::Email, 'body formatting' do
     expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
+  it 'should trim signature with non-breaking space after hyphens' do
+    body = <<-EOF
+      Hello.
+
+      --\xC2\xA0
+      Mr. Smith
+      CEO, company
+      t: 6174821300
+    EOF
+
+    expect(body_from_email(text: body)).to eq 'Hello.'
+  end
+
   it 'should remove any signature without space above Reply ABOVE THIS LINE' do
     body = <<-EOF
       Hello.


### PR DESCRIPTION
Fixes #207

The Ruby \s metacharacter only detects ASCII whitespace characters,
and emails encoded in UTF8 may contain \xC2\xA0 non-breaking spaces
(aka &nbsp;) which requires the [[:space:]] bracket expression instead.