### PR TITLE
fix valid_encoding? bug

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -65,7 +65,7 @@ module Griddler
 
     def text_or_sanitized_html
       text = clean_text(params.fetch(:text, ''))
-      text.presence || clean_html(params.fetch(:html, '')).presence
+      text.presence || clean_html(params.fetch(:html, ''))
     end
 
     def clean_text(text)


### PR DESCRIPTION
I am having a:
```
'undefined method `valid_encoding?' for nil:NilClass' 
```
bug in production. I think that the cause is that the `presence` method returns `nil` if `params.fetch(:html, '')` is an empty string. 