### PR TITLE
Fixes email address parsing when the email address may be blank

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -37,11 +37,12 @@ module Griddler
     end
 
     def recipients(type)
-      params[type].to_a.map { |recipient| extract_address(recipient) }
+      params[type].to_a.map { |recipient| extract_address(recipient) }.compact
     end
 
     def extract_address(address)
-      EmailParser.parse_address(clean_text(address))
+      clean_address = clean_text(address)    
+      EmailParser.parse_address(clean_address) if clean_address =~ /@/
     end
 
     def extract_body

--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -41,7 +41,7 @@ module Griddler
     end
 
     def extract_address(address)
-      clean_address = clean_text(address)    
+      clean_address = clean_text(address)
       EmailParser.parse_address(clean_address) if clean_address =~ /@/
     end
 

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -637,6 +637,18 @@ describe Griddler::Email, 'extracting email addresses' do
     expect(email.to).to eq [expected]
     expect(email.from).to eq expected
   end
+
+  it 'ignores blank email addresses' do
+    expected = @address_components
+    email = Griddler::Email.new(to: ['', @full_address])
+    expect(email.to).to eq [expected]
+  end
+
+  it 'ignores emails without @' do
+    expected = @address_components
+    email = Griddler::Email.new(to: ['johndoe', @full_address])
+    expect(email.to).to eq [expected]
+  end
 end
 
 describe Griddler::Email, 'extracting email addresses from CC field' do
@@ -659,6 +671,11 @@ describe Griddler::Email, 'extracting email addresses from CC field' do
   it 'returns an empty array when no CC address is added' do
     email = Griddler::Email.new(to: [@address], from: @address)
     expect(email.cc).to be_empty
+  end
+
+  it 'removes empty cc addresses' do
+    email = Griddler::Email.new(to: [@address], from: @address, cc: ['', @cc])
+    expect(email.cc.size).to eq(1)
   end
 end
 


### PR DESCRIPTION
We recently ran into a bug where sendgrid was sending us a `cc:` field with a blank email address.  The raw value was `, bob@example.com` and it would result in the exception `NoMethodError: undefined method 'delete' for nil:NilClass`.  This pull request aims to fix that exception.  The backtrace led to the line:

```
/gems/griddler-1.2.1/lib/griddler/email_parser.rb:63 in extract_email_address
/gems/griddler-1.2.1/lib/griddler/email_parser.rb:15 in parse_address
```

My approach was to skip calling `EmailParser.parse_address()` if there isn't at least an '@' in the cleaned version of the email address string.  My thought was that in order to be able to parse an email, you have to have an '@'.  This assumption may not be a correct assumption so I'm open to feedback that you have - we could just also check to see if `clean_address.strip.length == 0`.

I went the route of compacting the array post parsing since pre-parse the emails could have invalid UTF-8 chars and lead to bugs doing things prior to that step.

Look forward to hearing your thoughts and suggestions!

Thanks.