### PR TITLE
Sets default configuration without a config file

### DIFF
--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -16,7 +16,7 @@ module Griddler
   end
 
   class Configuration
-    attr_accessor :processor_class, :processor_method, :reply_delimiter
+    attr_accessor :processor_method
 
     def processor_class
       @processor_class ||=
@@ -48,7 +48,8 @@ module Griddler
     end
 
     def email_service
-      @email_service_adapter ||= Griddler.adapter_registry[:default]
+      return @email_service_adapter ||=
+        Griddler.adapter_registry[:default] || raise(Griddler::Errors::EmailServiceAdapterNotFound)
     end
 
     def email_service=(new_email_service)

--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -21,17 +21,14 @@ module Griddler
     def processor_class
       @processor_class ||=
         begin
-          if Kernel.const_defined?(:EmailProcessor)
-            "EmailProcessor"
-          else
-            raise NameError.new(<<-ERROR.strip_heredoc, 'EmailProcessor')
-              To use Griddler, you must either define `EmailProcessor` or configure a
-              different processor. See https://github.com/thoughtbot/griddler#defaults for
-              more information.
-            ERROR
-          end
+          EmailProcessor.to_s
+        rescue NameError
+          raise NameError.new(<<-ERROR.strip_heredoc, 'EmailProcessor')
+            To use Griddler, you must either define `EmailProcessor` or configure a
+            different processor. See https://github.com/thoughtbot/griddler#defaults for
+            more information.
+          ERROR
         end
-        
       @processor_class.constantize
     end
     

--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -31,7 +31,7 @@ module Griddler
         end
       @processor_class.constantize
     end
-    
+
     def processor_class=(klass)
       @processor_class = klass.to_s
     end
@@ -45,8 +45,9 @@ module Griddler
     end
 
     def email_service
-      return @email_service_adapter ||=
-        Griddler.adapter_registry[:default] || raise(Griddler::Errors::EmailServiceAdapterNotFound)
+      @email_service_adapter ||=
+        Griddler.adapter_registry[:default] ||
+        raise(Griddler::Errors::EmailServiceAdapterNotFound)
     end
 
     def email_service=(new_email_service)

--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -47,7 +47,7 @@ module Griddler
     def email_service
       @email_service_adapter ||=
         Griddler.adapter_registry[:default] ||
-        raise(Griddler::Errors::EmailServiceAdapterNotFound)
+          raise(Griddler::Errors::EmailServiceAdapterNotFound)
     end
 
     def email_service=(new_email_service)

--- a/spec/griddler/configuration_spec.rb
+++ b/spec/griddler/configuration_spec.rb
@@ -13,10 +13,11 @@ describe Griddler::Configuration do
       expect(Griddler.configuration.processor_method).to eq(:process)
     end
 
-    it 'raises a helpful error if EmailProcessor is undefined' #do
-    #   allow(Kernel).to receive_messages(const_defined?: false)
+    it 'raises a helpful error if EmailProcessor is undefined' # do
+    # allow(Kernel).to receive_messages(const_defined?: false)
 
-    #   expect { Griddler.configuration.processor_class }.to raise_error(NameError, %r{https://github\.com/thoughtbot/griddler#defaults})
+    # expect { Griddler.configuration.processor_class }.to raise_error(
+    #   NameError, %r{https://github\.com/thoughtbot/griddler#defaults})
     # end
   end
 

--- a/spec/griddler/configuration_spec.rb
+++ b/spec/griddler/configuration_spec.rb
@@ -13,11 +13,11 @@ describe Griddler::Configuration do
       expect(Griddler.configuration.processor_method).to eq(:process)
     end
 
-    it 'raises a helpful error if EmailProcessor is undefined' do
-      allow(Kernel).to receive_messages(const_defined?: false)
+    it 'raises a helpful error if EmailProcessor is undefined' #do
+    #   allow(Kernel).to receive_messages(const_defined?: false)
 
-      expect { Griddler.configuration.processor_class }.to raise_error(NameError, %r{https://github\.com/thoughtbot/griddler#defaults})
-    end
+    #   expect { Griddler.configuration.processor_class }.to raise_error(NameError, %r{https://github\.com/thoughtbot/griddler#defaults})
+    # end
   end
 
   describe 'with config block' do

--- a/spec/griddler/configuration_spec.rb
+++ b/spec/griddler/configuration_spec.rb
@@ -13,12 +13,19 @@ describe Griddler::Configuration do
       expect(Griddler.configuration.processor_method).to eq(:process)
     end
 
-    it 'raises a helpful error if EmailProcessor is undefined' # do
-    # allow(Kernel).to receive_messages(const_defined?: false)
+    it 'raises a helpful error if EmailProcessor is undefined' do
+      # temporarily undefine EmailProcessor
+      ep = EmailProcessor
+      Object.send(:remove_const, :EmailProcessor)
+      allow(ActiveSupport::Dependencies).to(
+        receive_messages(search_for_file: nil))
 
-    # expect { Griddler.configuration.processor_class }.to raise_error(
-    #   NameError, %r{https://github\.com/thoughtbot/griddler#defaults})
-    # end
+      expect { Griddler.configuration.processor_class }.to raise_error(
+        NameError, %r{https://github\.com/thoughtbot/griddler#defaults})
+
+      # restore EmailProcessor
+      EmailProcessor = ep
+    end
   end
 
   describe 'with config block' do


### PR DESCRIPTION
Relates to issue #187.

Previously, if a user included the griddler gem, but forgot to include the griddler-sendgrid gem (currently the default), and also did not create a configuration file, incoming email POSTs, failed with:

NoMethodError (undefined method `normalize_params' for nil:NilClass):
  griddler (1.2.1) app/controllers/griddler/emails_controller.rb:15:in `normalized_params'
  griddler (1.2.1) app/controllers/griddler/emails_controller.rb:3:in `create'
  ...

They will now error with:

Griddler::Errors::EmailServiceAdapterNotFound (Griddler::Errors::EmailServiceAdapterNotFound)


Also, without a configuration file, but with both griddler and griddler-sendgrid gems included, requests would fail with:

NameError (To use Griddler, you must either define `EmailProcessor` or configure a
different processor. See https://github.com/thoughtbot/griddler#defaults for
more information.
):

This has been corrected as well.  However, I am not sure the best way to update the configuration_spec:16 to undefine the class setup in the dummy environment.  Thoughts?