### PR TITLE
Add #extras so adapters can add extra params.

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -4,7 +4,7 @@ module Griddler
   class Email
     include ActionView::Helpers::SanitizeHelper
     attr_reader :to, :from, :cc, :bcc, :subject, :body, :raw_body, :raw_text, :raw_html,
-      :headers, :raw_headers, :attachments
+      :headers, :raw_headers, :attachments, :extras
 
     def initialize(params)
       @params = params
@@ -26,6 +26,7 @@ module Griddler
       @raw_headers = params[:headers]
 
       @attachments = params[:attachments]
+      @extras = params[:extras] || {}
     end
 
     private

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -784,3 +784,23 @@ This is the real text\r\n\r\n\r\nOn Fri, Mar 21, 2014 at 3:11 PM, Someone <\r\ns
     end
   end
 end
+
+describe Griddler::Email, 'extras param from adapter' do
+  it 'uses passes along adapter what the adapter sets' do
+    email = email_with_extras({ 'testing' => '123' })
+    expect(email.extras).to eq({ 'testing' => '123' })
+  end
+
+  it 'defaults to empty hash' do
+    email = email_with_extras(nil)
+    expect(email.extras).to eq({})
+  end
+
+  def email_with_extras(extras)
+    Griddler::Email.new({
+      to: ['hi@example.com'],
+      from: 'bye@example.com',
+      extras: extras
+    })
+  end
+end

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -787,8 +787,8 @@ end
 
 describe Griddler::Email, 'extras param from adapter' do
   it 'uses passes along adapter what the adapter sets' do
-    email = email_with_extras({ 'testing' => '123' })
-    expect(email.extras).to eq({ 'testing' => '123' })
+    email = email_with_extras('testing' => '123')
+    expect(email.extras).to eq('testing' => '123')
   end
 
   it 'defaults to empty hash' do
@@ -797,10 +797,10 @@ describe Griddler::Email, 'extras param from adapter' do
   end
 
   def email_with_extras(extras)
-    Griddler::Email.new({
+    Griddler::Email.new(
       to: ['hi@example.com'],
       from: 'bye@example.com',
-      extras: extras
-    })
+      extras: extras,
+    )
   end
 end


### PR DESCRIPTION
Just adds a place for adapters to put adapter-specific params so they can be accessed from a Griddler::Email.

This was [briefly discussed](https://github.com/bradpauly/griddler-mailgun/issues/4) way back and I wanted to see if anyone is still interested.
