### PR TITLE
Add support for adapter specific configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Griddler.configure do |config|
   config.processor_method = :process # :create_comment (A method on CommentViaEmail)
   config.reply_delimiter = '-- REPLY ABOVE THIS LINE --'
   config.email_service = :sendgrid # :cloudmailin, :postmark, :mandrill, :mailgun
+  config.extra_configuration = {}
 end
 ```
 
@@ -65,6 +66,7 @@ end
 | `processor_method` | The method Griddler will call on the processor class when handling your incoming emails.
 | `reply_delimiter`  | The string searched for that will split your body.
 | `email_service`    | Tells Griddler which email service you are using. The supported email service options are `:sendgrid` (the default), `:cloudmailin` (expects multipart format), `:postmark`, `:mandrill` and `:mailgun`. You will also need to have an appropriate [adapter] gem included in your Gemfile.
+| `extra_configuration`  | A hash of additional configuration options that are passed on to the adapter. See the individual adapters for supported values.
 
 By default Griddler will look for a class named `EmailProcessor`. The class is
 initialized with a `Griddler::Email` instance representing the incoming

--- a/app/controllers/griddler/emails_controller.rb
+++ b/app/controllers/griddler/emails_controller.rb
@@ -12,7 +12,7 @@ class Griddler::EmailsController < ActionController::Base
   delegate :processor_class, :processor_method, :email_service, to: :griddler_configuration
 
   def normalized_params
-    Array.wrap(email_service.normalize_params(params))
+    Array.wrap(email_service.normalize_params(params, extra_configuration))
   end
 
   def process_email(email)
@@ -21,5 +21,9 @@ class Griddler::EmailsController < ActionController::Base
 
   def griddler_configuration
     Griddler.configuration
+  end
+
+  def extra_configuration
+    griddler_configuration.extra_configuration
   end
 end

--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -16,7 +16,16 @@ module Griddler
   end
 
   class Configuration
-    attr_accessor :processor_class, :processor_method, :reply_delimiter
+    attr_accessor :processor_class, :processor_method, :reply_delimiter,
+                  :extra_configuration
+
+    def extra_configuration=(config)
+      @extra_configuration = config
+    end
+
+    def extra_configuration
+      @extra_configuration ||= {}
+    end
 
     def processor_class
       @processor_class ||=
@@ -31,10 +40,10 @@ module Griddler
             ERROR
           end
         end
-        
+
       @processor_class.constantize
     end
-    
+
     def processor_class=(klass)
       @processor_class = klass.to_s
     end

--- a/spec/dummy/app/models/email_processor.rb
+++ b/spec/dummy/app/models/email_processor.rb
@@ -1,6 +1,7 @@
 class EmailProcessor
-  def initialize(email)
+  def initialize(email, config)
     @email = email
+    @config = config
   end
 
   def process; end

--- a/spec/griddler/configuration_spec.rb
+++ b/spec/griddler/configuration_spec.rb
@@ -11,6 +11,7 @@ describe Griddler::Configuration do
       expect(Griddler.configuration.reply_delimiter).to eq('-- REPLY ABOVE THIS LINE --')
       expect(Griddler.configuration.email_service).to eq(:test_adapter)
       expect(Griddler.configuration.processor_method).to eq(:process)
+      expect(Griddler.configuration.extra_configuration).to eq({})
     end
 
     it 'raises a helpful error if EmailProcessor is undefined' do
@@ -25,8 +26,21 @@ describe Griddler::Configuration do
       Griddler.configure
     end
 
+    it 'stores extra configuration' do
+      extra_config = {
+        option1: 'foo',
+        option2: 'bar'
+      }
+
+      Griddler.configure do |config|
+        config.extra_configuration = extra_config
+      end
+
+      expect(Griddler.configuration.extra_configuration).to eq(extra_config)
+    end
+
     it 'stores a processor_class' do
-      class DummyProcessor 
+      class DummyProcessor
       end
 
       Griddler.configure do |config|


### PR DESCRIPTION
This is a PR for #225. Essentially, this provides the ability for additional configuration options to be passed into an individual adapter.

Extra configuration is passed in as a hash during the `Griddler.configure` call.

For an example implementation and use case, see wingrunr21/griddler-mandrill#23 and the [`spf_config`](https://github.com/wingrunr21/griddler-mandrill/tree/spf_config) branch of `griddler-mandrill`.
