### PR TITLE
Make the code resilient against an empty recipient.

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -37,7 +37,9 @@ module Griddler
     end
 
     def recipients(type)
-      params[type].to_a.map { |recipient| extract_address(recipient) }
+      params[type].to_a.reject(&:empty?).map do |recipient|
+        extract_address(recipient)
+      end
     end
 
     def extract_address(address)

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -783,4 +783,19 @@ This is the real text\r\n\r\n\r\nOn Fri, Mar 21, 2014 at 3:11 PM, Someone <\r\ns
       expect(email.to.map { |to| to[:full] }).to eq recipients
     end
   end
+
+  context 'with an empty recipient in to field' do
+    it 'includes all of the emails' do
+      recipients =
+        ['caleb@example.com',
+         '',
+         '<joel@example.com>',
+         'Swift <swift@example.com>']
+      params = { to: recipients, from: 'ralph@example.com', text: 'hi guys' }
+
+      email = Griddler::Email.new(params)
+
+      expect(email.to.map { |to| to[:full] }).to eq recipients.reject(&:empty?)
+    end
+  end
 end


### PR DESCRIPTION
Currently the code raises a NoMethodError when there is an empty recipient in the 'To' list.  This change filters out such empty recipients, ensuring that the email is properly parsed in this case.