### PR TITLE
Handle "YYYY-MM-DD *" format

### DIFF
--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -84,7 +84,7 @@ module Griddler::EmailParser
       /^On.*<\n?.*>.*\n?wrote:$/,
       /On.*wrote:/,
       /\*?From:.*$/i,
-      /^[[:space:]]*\d{4}\/\d{1,2}\/\d{1,2}[[:space:]].*[[:space:]]<.*>?$/i
+      /^[[:space:]]*\d{4}[-\/]\d{1,2}[-\/]\d{1,2}[[:space:]].*[[:space:]]<.*>?$/i
     ]
   end
 

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -108,6 +108,21 @@ describe Griddler::Email, 'body formatting' do
     expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
+  it 'handles "[date] [soandso] <email@example.com>:" format' do
+    body = <<-EOF
+      Hello.
+
+      2016-03-03 11:35 GMT+01:00 Bob <email@example.com>:
+      > Check out this report.
+      >
+      > It's pretty cool.
+      >
+      > Thanks, Tristan
+    EOF
+
+    expect(body_from_email(text: body)).to eq 'Hello.'
+  end
+
   it 'handles "On [date] [soandso]<\nverylongemailaddress@longdomain.com>\nwrote:" format' do
     body = <<-EOF.strip_heredoc
       Hello.


### PR DESCRIPTION
The purpose of this pull request is to handle the following format:

```
Anwser

2016-03-03 11:35 GMT+01:00 Bob <email@example.com>:
> Whatever
```

(the default when sending an email from my Gmail)