### PR TITLE
Handles most common French and Spanish formats

### DIFF
--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -85,7 +85,8 @@ module Griddler::EmailParser
       /On.*wrote:/,
       /\*?From:.*$/i,
       /^[[:space:]]*\d{4}[-\/]\d{1,2}[-\/]\d{1,2}[[:space:]].*[[:space:]]<.*>?$/i,
-      /^[[:space:]]*\>?[[:space:]]*Le.*<\n?.*>.*\n?a[[:space:]]?\n?écrit :$/, # French
+      /\n[[:space:]]*De :.*\n[[:space:]]*Envoyé :.*\n[[:space:]]*Objet :.*\n$/i, # French
+      /^[[:space:]]*\>?[[:space:]]*Le.*<\n?.*>.*\n?a[[:space:]]?\n?écrit :$/,    # French
       /^[[:space:]]*\>?[[:space:]]*El.*<\n?.*>.*\n?escribió:$/ # Spanish
     ]
   end

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -85,8 +85,8 @@ module Griddler::EmailParser
       /On.*wrote:/,
       /\*?From:.*$/i,
       /^[[:space:]]*\d{4}[-\/]\d{1,2}[-\/]\d{1,2}[[:space:]].*[[:space:]]<.*>?$/i,
-      /\n[[:space:]]*De :.*\n[[:space:]]*Envoyé :.*\n[[:space:]]*Objet :.*\n$/i, # French
-      /^[[:space:]]*\>?[[:space:]]*Le.*<\n?.*>.*\n?a[[:space:]]?\n?écrit :$/,    # French
+      /(_)*\n[[:space:]]*De :.*\n[[:space:]]*Envoyé :.*\n[[:space:]]*À :.*\n[[:space:]]*Objet :.*\n$/i, # French Outlook
+      /^[[:space:]]*\>?[[:space:]]*Le.*<\n?.*>.*\n?a[[:space:]]?\n?écrit :$/, # French
       /^[[:space:]]*\>?[[:space:]]*El.*<\n?.*>.*\n?escribió:$/ # Spanish
     ]
   end

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -84,7 +84,9 @@ module Griddler::EmailParser
       /^On.*<\n?.*>.*\n?wrote:$/,
       /On.*wrote:/,
       /\*?From:.*$/i,
-      /^[[:space:]]*\d{4}[-\/]\d{1,2}[-\/]\d{1,2}[[:space:]].*[[:space:]]<.*>?$/i
+      /^[[:space:]]*\d{4}[-\/]\d{1,2}[-\/]\d{1,2}[[:space:]].*[[:space:]]<.*>?$/i,
+      /^[[:space:]]*\>?[[:space:]]*Le.*<\n?.*>.*\n?a[[:space:]]?\n?écrit :$/, # French
+      /^[[:space:]]*\>?[[:space:]]*El.*<\n?.*>.*\n?escribió:$/ # Spanish
     ]
   end
 

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -157,6 +157,73 @@ describe Griddler::Email, 'body formatting' do
     expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
+  it 'handles french format: "Le [date], [soandso] <email@example.com> a écrit :"' do
+    body = <<-EOF.strip_heredoc
+      Hello.
+
+      Le 11 mars 2016, at 18:00, Tristan <email@example.com> a écrit :
+      > Check out this report.
+      >
+      > It's pretty cool.
+      >
+      > Thanks, Tristan
+      >
+    EOF
+
+    expect(body_from_email(text: body)).to eq 'Hello.'
+  end
+
+  it 'handles LONG french format: "Le [date], [soandso] <email@example.com> a écrit :"' do
+    body = <<-EOF.strip_heredoc
+      Hello.
+
+      Le 11 mars 2016, at 18:00, Tristan With A Really Really Long Name <
+      tristanhasasuperlongemailthatforcesanewline@candidates.welcomekit.co> a
+      écrit :
+      > Check out this report.
+      >
+      > It's pretty cool.
+      >
+      > Thanks, Tristan
+      >
+    EOF
+
+    expect(body_from_email(text: body)).to eq 'Hello.'
+  end
+
+  it 'handles spanish format: "El [date], [soandso] <email@example.com> escribió:"' do
+    body = <<-EOF.strip_heredoc
+      Hello.
+
+      El 11/03/2016 11:34, Pedro Pérez <email@example.com> escribió:
+      > Check out this report.
+      >
+      > It's pretty cool.
+      >
+      > Thanks, Pedro
+      >
+    EOF
+
+    expect(body_from_email(text: body)).to eq 'Hello.'
+  end
+
+  it 'handles LONG spanish format: "El [date], [soandso] <email@example.com> escribió:"' do
+    body = <<-EOF.strip_heredoc
+      Hello.
+
+      El 11/03/2016 11:34, Pedro Pérez <
+      pedrohasasuperlongemailthatforcesanewline@example.com> escribió:
+      > Check out this report.
+      >
+      > It's pretty cool.
+      >
+      > Thanks, Pedro
+      >
+    EOF
+
+    expect(body_from_email(text: body)).to eq 'Hello.'
+  end
+
   it 'handles "From: email@email.com" format' do
     body = <<-EOF
       Hello.

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -252,6 +252,20 @@ describe Griddler::Email, 'body formatting' do
     expect(body_from_email(text: body)).to eq 'Hello.'
   end
 
+  it 'handles "De : Firstname <email@email.com>" format (french Outlook)' do
+    body = <<-EOF
+      Hello.
+
+      De : Bob <bob@example.com>
+      Envoyé : mardi 31 mai 2016 14:27:49
+      Objet : Awesome report.
+
+      Check out this report!
+    EOF
+
+    expect(body_from_email(text: body)).to eq 'Hello.'
+  end
+
   it 'handles "-----Original Message-----" format' do
     body = <<-EOF
       Hello.

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -256,8 +256,10 @@ describe Griddler::Email, 'body formatting' do
     body = <<-EOF
       Hello.
 
+      ________________________________
       De : Bob <bob@example.com>
-      Envoyé : mardi 31 mai 2016 14:27:49
+      Envoyé : mercredi 15 juin 2016 07:24
+      À : robert@example.com
       Objet : Awesome report.
 
       Check out this report!


### PR DESCRIPTION
Fix email parsing for most common French and Spanish formats (based on Gmail formatting) : 
- French: `Le 11 mars 2016, at 18:00, Tristan <email@example.com> a écrit :`
- Spanish: `El 11/03/2016 11:34, Pedro Pérez <email@example.com> escribió:`

This fixes #163 
