### PR TITLE
add new adapter for SparkPost

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,11 +168,13 @@ adapter gem in addition to `griddler`.
 | mandrill    | [griddler-mandrill]
 | mailgun     | [griddler-mailgun]
 | postmark    | [griddler-postmark]
+| sparkpost   | [griddler-sparkpost]
 
 [griddler-sendgrid]: https://github.com/thoughtbot/griddler-sendgrid
 [griddler-mandrill]: https://github.com/wingrunr21/griddler-mandrill
 [griddler-mailgun]: https://github.com/bradpauly/griddler-mailgun
 [griddler-postmark]: https://github.com/r38y/griddler-postmark
+[griddler-sparkpost]: https://github.com/PrestoDoctor/griddler-sparkpost
 
 Writing an Adapter
 ------------------


### PR DESCRIPTION
Not super well tested just yet, but it's being used in our production app and is working fine. SparkPost doesn't automatically parse out attachments, so it's done in the adapter.