### PR TITLE
Allowing user defined Email class to be used.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Defaults are shown below with sample overrides following. In
 ```ruby
 Griddler.configure do |config|
   config.processor_class = EmailProcessor # CommentViaEmail
+  config.email_class = Griddler::Email # MyEmail
   config.processor_method = :process # :create_comment (A method on CommentViaEmail)
   config.reply_delimiter = '-- REPLY ABOVE THIS LINE --'
   config.email_service = :sendgrid # :cloudmailin, :postmark, :mandrill, :mailgun
@@ -62,6 +63,7 @@ end
 | Option             | Meaning
 | ------             | -------
 | `processor_class`  | The class Griddler will use to handle your incoming emails.
+| `email_class`      | The class Griddler will use to represent an incoming e-mail. It must support an initializer that receives a hash as the only argument. We recommend inheriting it from Griddler::Email or checking this class to see all the methods it responds to.
 | `processor_method` | The method Griddler will call on the processor class when handling your incoming emails.
 | `reply_delimiter`  | The string searched for that will split your body.
 | `email_service`    | Tells Griddler which email service you are using. The supported email service options are `:sendgrid` (the default), `:cloudmailin` (expects multipart format), `:postmark`, `:mandrill` and `:mailgun`. You will also need to have an appropriate [adapter] gem included in your Gemfile.

--- a/app/controllers/griddler/emails_controller.rb
+++ b/app/controllers/griddler/emails_controller.rb
@@ -1,7 +1,7 @@
 class Griddler::EmailsController < ActionController::Base
   def create
     normalized_params.each do |p|
-      process_email Griddler::Email.new(p)
+      process_email email_class.new(p)
     end
 
     head :ok
@@ -9,9 +9,9 @@ class Griddler::EmailsController < ActionController::Base
 
   private
 
-  delegate :processor_class, :processor_method, :email_service, to: :griddler_configuration
+  delegate :processor_class, :email_class, :processor_method, :email_service, to: :griddler_configuration
 
-  private :processor_class, :processor_method, :email_service
+  private :processor_class, :email_class, :processor_method, :email_service
 
   def normalized_params
     Array.wrap(email_service.normalize_params(params))

--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -36,6 +36,14 @@ module Griddler
       @processor_class = klass.to_s
     end
 
+    def email_class
+      @email_class ||= Griddler::Email
+    end
+
+    def email_class=(klass)
+      @email_class = klass
+    end
+
     def processor_method
       @processor_method ||= :process
     end

--- a/lib/griddler/configuration.rb
+++ b/lib/griddler/configuration.rb
@@ -17,6 +17,7 @@ module Griddler
 
   class Configuration
     attr_accessor :processor_method, :reply_delimiter
+    attr_writer :email_class
 
     def processor_class
       @processor_class ||=
@@ -38,10 +39,6 @@ module Griddler
 
     def email_class
       @email_class ||= Griddler::Email
-    end
-
-    def email_class=(klass)
-      @email_class = klass
     end
 
     def processor_method

--- a/spec/griddler/configuration_spec.rb
+++ b/spec/griddler/configuration_spec.rb
@@ -8,6 +8,7 @@ describe Griddler::Configuration do
 
     it 'provides defaults' do
       expect(Griddler.configuration.processor_class).to eq(EmailProcessor)
+      expect(Griddler.configuration.email_class).to eq(Griddler::Email)
       expect(Griddler.configuration.reply_delimiter).to eq('-- REPLY ABOVE THIS LINE --')
       expect(Griddler.configuration.email_service).to eq(:test_adapter)
       expect(Griddler.configuration.processor_method).to eq(:process)
@@ -42,6 +43,17 @@ describe Griddler::Configuration do
       end
 
       expect(Griddler.configuration.processor_class).to eq DummyProcessor
+    end
+
+    it 'stores an email_class' do
+      class DummyEmail
+      end
+
+      Griddler.configure do |config|
+        config.email_class = DummyEmail
+      end
+
+      expect(Griddler.configuration.email_class).to eq DummyEmail
     end
 
     it 'stores a processor_method' do


### PR DESCRIPTION
This gives the user more flexibility when parsing an e-mail. By default, Griddler::Email is used.