### PR TITLE
Adds `#to_h` to return a hash of Email attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Griddler::Email attributes
 | `#attachments` | An array of `File` objects containing any attachments.
 | `#headers`     | A hash of headers parsed by `Mail::Header`, unless they are already formatted as a hash when received from the adapter in which case the original hash is returned.
 | `#raw_headers` | The raw headers included in the message.
+| `#to_h`        | A hash of the above attributes.
 
 ### Email Addresses
 

--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -28,6 +28,23 @@ module Griddler
       @attachments = params[:attachments]
     end
 
+    def to_h
+      @to_h ||= {
+        to: to,
+        from: from,
+        cc: cc,
+        bcc: bcc,
+        subject: subject,
+        body: body,
+        raw_body: raw_body,
+        raw_text: raw_text,
+        raw_html: raw_html,
+        headers: headers,
+        raw_headers: raw_headers,
+        attachments: attachments,
+      }
+    end
+
     private
 
     attr_reader :params

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -868,3 +868,40 @@ This is the real text\r\n\r\nOn Tue, Jun 14, 2016 at 10:25 AM Someone <\r\nveryl
     end
   end
 end
+
+describe Griddler::Email, 'methods' do
+  describe '#to_h' do
+    it 'returns an indifferent access hash of Griddler::Email attributes' do
+      params = {
+        to: ['Some Identifier <some-identifier@example.com>'],
+        from: 'Joe User <joeuser@example.com>',
+        subject: 'Re: [ThisApp] That thing',
+        text: <<-EOS.strip_heredoc.strip
+          lololololo hi
+
+          -- REPLY ABOVE THIS LINE --
+
+          hey sup
+        EOS
+      }
+      email = Griddler::Email.new(params)
+
+      hash = email.to_h
+
+      expect(hash).to eq(
+        to: email.to,
+        from: email.from,
+        cc: email.cc,
+        bcc: email.bcc,
+        subject: email.subject,
+        body: email.body,
+        raw_body: email.raw_body,
+        raw_text: email.raw_text,
+        raw_html: email.raw_html,
+        headers: email.headers,
+        raw_headers: email.raw_headers,
+        attachments: email.attachments,
+      )
+    end
+  end
+end


### PR DESCRIPTION
Our use case for this is to log the hash version of `Email` with our exception tracking service whenever there's a problem processing the email.