### PR TITLE
Add CloudMailin to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ adapter gem in addition to `griddler`.
 | Service     | Adapter
 | -------     | -------
 | sendgrid    | [griddler-sendgrid]
+| cloudmailin | [griddler-cloudmailin]
 | mandrill    | [griddler-mandrill]
 | mailgun     | [griddler-mailgun]
 | postmark    | [griddler-postmark]
@@ -175,6 +176,7 @@ adapter gem in addition to `griddler`.
 | ses (amazon)| [griddler-ses]
 
 [griddler-sendgrid]: https://github.com/thoughtbot/griddler-sendgrid
+[griddler-cloudmailin]: https://github.com/thoughtbot/griddler-cloudmailin
 [griddler-mandrill]: https://github.com/wingrunr21/griddler-mandrill
 [griddler-mailgun]: https://github.com/bradpauly/griddler-mailgun
 [griddler-postmark]: https://github.com/r38y/griddler-postmark


### PR DESCRIPTION
The CloudMailin adapter was originally a thoughtbot gem.
I'm not sure why it's not included in the docs but it is maintained.