### PR TITLE
Specify incompatibility with Rails 5

### DIFF
--- a/griddler.gemspec
+++ b/griddler.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,lib}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
   s.require_paths = %w{app lib}
 
-  s.add_dependency 'rails', '>= 3.2.0'
+  s.add_dependency 'rails', '>= 3.2.0', '< 5'
   s.add_dependency 'htmlentities'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
Issue #279 details that Griddler isn't compatible with Rails 5. This change updates the gemspec to specify that in code.

When the issue is resolved, the gemspec should relax this requirement again.