### PR TITLE
Add params[:vendor_specific] to Griddler::Email

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -28,7 +28,7 @@ module Griddler
 
       @attachments = params[:attachments]
 
-      @vendor_specific = params[:vendor_specific] || {}
+      @vendor_specific = params.fetch(:vendor_specific, {})
     end
 
     def to_h

--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -3,8 +3,9 @@ require 'htmlentities'
 module Griddler
   class Email
     include ActionView::Helpers::SanitizeHelper
+
     attr_reader :to, :from, :cc, :bcc, :subject, :body, :raw_body, :raw_text, :raw_html,
-      :headers, :raw_headers, :attachments
+                :headers, :raw_headers, :attachments, :vendor_specific
 
     def initialize(params)
       @params = params
@@ -26,6 +27,8 @@ module Griddler
       @raw_headers = params[:headers]
 
       @attachments = params[:attachments]
+
+      @vendor_specific = params[:vendor_specific] || {}
     end
 
     def to_h
@@ -42,6 +45,7 @@ module Griddler
         headers: headers,
         raw_headers: raw_headers,
         attachments: attachments,
+        vendor_specific: vendor_specific,
       }
     end
 

--- a/lib/griddler/version.rb
+++ b/lib/griddler/version.rb
@@ -1,3 +1,3 @@
 module Griddler
-  VERSION = '1.4.1'
+  VERSION = '1.4.0'
 end

--- a/lib/griddler/version.rb
+++ b/lib/griddler/version.rb
@@ -1,3 +1,3 @@
 module Griddler
-  VERSION = '1.4.0'
+  VERSION = '1.4.1'
 end

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -869,6 +869,30 @@ This is the real text\r\n\r\nOn Tue, Jun 14, 2016 at 10:25 AM Someone <\r\nveryl
   end
 end
 
+describe Griddler::Email, 'extracting vendor specific' do
+  it 'extracts a hash of vendor specific data' do
+    meeting_info = {
+      name: 'Weekly Stand Up',
+      date: '01/01/2015',
+      time: '8:00am'
+    }
+    params = {
+      vendor_specific: {
+        body_calendar: meeting_info
+      }
+    }
+    email = Griddler::Email.new(params)
+
+    expect(email.vendor_specific).to eq({ body_calendar: meeting_info })
+  end
+
+  it 'defaults to an empty hash' do
+    email = Griddler::Email.new({})
+
+    expect(email.vendor_specific).to eq({})
+  end
+end
+
 describe Griddler::Email, 'methods' do
   describe '#to_h' do
     it 'returns an indifferent access hash of Griddler::Email attributes' do
@@ -901,6 +925,7 @@ describe Griddler::Email, 'methods' do
         headers: email.headers,
         raw_headers: email.raw_headers,
         attachments: email.attachments,
+        vendor_specific: {},
       )
     end
   end


### PR DESCRIPTION
Similar to @bradpauly's PR (https://github.com/thoughtbot/griddler/pull/233). This adds the ability to pass vendor_specific data to `Griddler::Email` 

I do see this attribute becoming a dumping ground but I think the vendors are different enough that trying to standardize "vendor specific" data would be a futile exercise. Essentially, being a dumping ground might actually be what it's meant for? 