### PR TITLE
Internationalize regex split points

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,9 @@
+en:
+  regex:
+    original_message: ^[[:space:]]*[-]+[[:space:]]*Original Message[[:space:]]*[-]+[[:space:]]*$
+    signature_line: ^[[:space:]]*--[[:space:]]*$
+    on_date_soandso_wrote: ^[[:space:]]*\>?[[:space:]]*On.*\r?\n?.*wrote:\r?\n?$
+    long_email_address_wrote: ^On.*<\r?\n?.*>.*\r?\n?wrote:\r?\n?$
+    everything_on_one_line: "On.*wrote:"
+    from_format: \*?From:.*$
+    date_soandso: ^[[:space:]]*\d{4}[-\/]\d{1,2}[-\/]\d{1,2}[[:space:]].*[[:space:]]<.*>?$

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,5 @@
 en:
-  regex:
+  split_point:
     original_message: ^[[:space:]]*[-]+[[:space:]]*Original Message[[:space:]]*[-]+[[:space:]]*$
     signature_line: ^[[:space:]]*--[[:space:]]*$
     on_date_soandso_wrote: ^[[:space:]]*\>?[[:space:]]*On.*\r?\n?.*wrote:\r?\n?$

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,3 +1,3 @@
 es:
-  regex:
+  split_point:
     on_date_soandso_wrote: ^[[:space:]]*\>?[[:space:]]*El.*<\n?.*>.*\n?escribió:$

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,3 @@
+es:
+  regex:
+    on_date_soandso_wrote: ^[[:space:]]*\>?[[:space:]]*El.*<\n?.*>.*\n?escribió:$

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,4 +1,4 @@
 fr:
-  regex:
+  split_point:
     on_date_soandso_wrote: ^[[:space:]]*\>?[[:space:]]*Le.*<\n?.*>.*\n?a[[:space:]]?\n?écrit :$
     from_format: (_)*\n[[:space:]]*De :.*\n[[:space:]]*Envoyé :.*\n[[:space:]]*À :.*\n[[:space:]]*Objet :.*\n$

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,4 @@
+fr:
+  regex:
+    on_date_soandso_wrote: ^[[:space:]]*\>?[[:space:]]*Le.*<\n?.*>.*\n?a[[:space:]]?\n?écrit :$
+    from_format: (_)*\n[[:space:]]*De :.*\n[[:space:]]*Envoyé :.*\n[[:space:]]*À :.*\n[[:space:]]*Objet :.*\n$

--- a/griddler.gemspec
+++ b/griddler.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 3.2.0'
   s.add_dependency 'htmlentities'
+  s.add_dependency 'i18n'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'pry'

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -78,13 +78,13 @@ module Griddler::EmailParser
   def self.regex_split_points
     [
       reply_delimeter_regex,
-      Regexp.new(I18n.t('regex.original_message'), Regexp::IGNORECASE),
-      Regexp.new(I18n.t('regex.signature_line')),
-      Regexp.new(I18n.t('regex.on_date_soandso_wrote')),
-      Regexp.new(I18n.t('regex.long_email_address_wrote')),
-      Regexp.new(I18n.t('regex.everything_on_one_line')),
-      Regexp.new(I18n.t('regex.from_format'), Regexp::IGNORECASE),
-      Regexp.new(I18n.t('regex.date_soandso'), Regexp::IGNORECASE),
+      Regexp.new(I18n.t('split_point.original_message'), Regexp::IGNORECASE),
+      Regexp.new(I18n.t('split_point.signature_line')),
+      Regexp.new(I18n.t('split_point.on_date_soandso_wrote')),
+      Regexp.new(I18n.t('split_point.long_email_address_wrote')),
+      Regexp.new(I18n.t('split_point.everything_on_one_line')),
+      Regexp.new(I18n.t('split_point.from_format'), Regexp::IGNORECASE),
+      Regexp.new(I18n.t('split_point.date_soandso'), Regexp::IGNORECASE),
     ]
   end
 

--- a/lib/griddler/email_parser.rb
+++ b/lib/griddler/email_parser.rb
@@ -78,16 +78,13 @@ module Griddler::EmailParser
   def self.regex_split_points
     [
       reply_delimeter_regex,
-      /^[[:space:]]*[-]+[[:space:]]*Original Message[[:space:]]*[-]+[[:space:]]*$/i,
-      /^[[:space:]]*--[[:space:]]*$/,
-      /^[[:space:]]*\>?[[:space:]]*On.*\r?\n?.*wrote:\r?\n?$/,
-      /^On.*<\r?\n?.*>.*\r?\n?wrote:\r?\n?$/,
-      /On.*wrote:/,
-      /\*?From:.*$/i,
-      /^[[:space:]]*\d{4}[-\/]\d{1,2}[-\/]\d{1,2}[[:space:]].*[[:space:]]<.*>?$/i,
-      /(_)*\n[[:space:]]*De :.*\n[[:space:]]*Envoyé :.*\n[[:space:]]*À :.*\n[[:space:]]*Objet :.*\n$/i, # French Outlook
-      /^[[:space:]]*\>?[[:space:]]*Le.*<\n?.*>.*\n?a[[:space:]]?\n?écrit :$/, # French
-      /^[[:space:]]*\>?[[:space:]]*El.*<\n?.*>.*\n?escribió:$/ # Spanish
+      Regexp.new(I18n.t('regex.original_message'), Regexp::IGNORECASE),
+      Regexp.new(I18n.t('regex.signature_line')),
+      Regexp.new(I18n.t('regex.on_date_soandso_wrote')),
+      Regexp.new(I18n.t('regex.long_email_address_wrote')),
+      Regexp.new(I18n.t('regex.everything_on_one_line')),
+      Regexp.new(I18n.t('regex.from_format'), Regexp::IGNORECASE),
+      Regexp.new(I18n.t('regex.date_soandso'), Regexp::IGNORECASE),
     ]
   end
 

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -160,15 +160,15 @@ describe Griddler::Email, 'body formatting' do
   it 'handles french format: "Le [date], [soandso] <email@example.com> a écrit :"' do
     I18n.with_locale(:fr) do
       body = <<-EOF.strip_heredoc
-      Hello.
+        Hello.
 
-      Le 11 mars 2016, at 18:00, Tristan <email@example.com> a écrit :
-      > Check out this report.
-      >
-      > It's pretty cool.
-      >
-      > Thanks, Tristan
-      >
+        Le 11 mars 2016, at 18:00, Tristan <email@example.com> a écrit :
+        > Check out this report.
+        >
+        > It's pretty cool.
+        >
+        > Thanks, Tristan
+        >
       EOF
 
       expect(body_from_email(text: body)).to eq 'Hello.'
@@ -178,17 +178,17 @@ describe Griddler::Email, 'body formatting' do
   it 'handles LONG french format: "Le [date], [soandso] <email@example.com> a écrit :"' do
     I18n.with_locale(:fr) do
       body = <<-EOF.strip_heredoc
-      Hello.
+        Hello.
 
-      Le 11 mars 2016, at 18:00, Tristan With A Really Really Long Name <
-      tristanhasasuperlongemailthatforcesanewline@candidates.welcomekit.co> a
-      écrit :
-      > Check out this report.
-      >
-      > It's pretty cool.
-      >
-      > Thanks, Tristan
-      >
+        Le 11 mars 2016, at 18:00, Tristan With A Really Really Long Name <
+        tristanhasasuperlongemailthatforcesanewline@candidates.welcomekit.co> a
+        écrit :
+        > Check out this report.
+        >
+        > It's pretty cool.
+        >
+        > Thanks, Tristan
+        >
       EOF
 
       expect(body_from_email(text: body)).to eq 'Hello.'
@@ -198,15 +198,15 @@ describe Griddler::Email, 'body formatting' do
   it 'handles spanish format: "El [date], [soandso] <email@example.com> escribió:"' do
     I18n.with_locale(:es) do
       body = <<-EOF.strip_heredoc
-      Hello.
+        Hello.
 
-      El 11/03/2016 11:34, Pedro Pérez <email@example.com> escribió:
-      > Check out this report.
-      >
-      > It's pretty cool.
-      >
-      > Thanks, Pedro
-      >
+        El 11/03/2016 11:34, Pedro Pérez <email@example.com> escribió:
+        > Check out this report.
+        >
+        > It's pretty cool.
+        >
+        > Thanks, Pedro
+        >
       EOF
 
       expect(body_from_email(text: body)).to eq 'Hello.'
@@ -216,16 +216,16 @@ describe Griddler::Email, 'body formatting' do
   it 'handles LONG spanish format: "El [date], [soandso] <email@example.com> escribió:"' do
     I18n.with_locale(:es) do
       body = <<-EOF.strip_heredoc
-      Hello.
+        Hello.
 
-      El 11/03/2016 11:34, Pedro Pérez <
-      pedrohasasuperlongemailthatforcesanewline@example.com> escribió:
-      > Check out this report.
-      >
-      > It's pretty cool.
-      >
-      > Thanks, Pedro
-      >
+        El 11/03/2016 11:34, Pedro Pérez <
+        pedrohasasuperlongemailthatforcesanewline@example.com> escribió:
+        > Check out this report.
+        >
+        > It's pretty cool.
+        >
+        > Thanks, Pedro
+        >
       EOF
 
       expect(body_from_email(text: body)).to eq 'Hello.'
@@ -263,15 +263,15 @@ describe Griddler::Email, 'body formatting' do
   it 'handles "De : Firstname <email@email.com>" format (french Outlook)' do
     I18n.with_locale(:fr) do
       body = <<-EOF
-      Hello.
+        Hello.
 
-      ________________________________
-      De : Bob <bob@example.com>
-      Envoyé : mercredi 15 juin 2016 07:24
-      À : robert@example.com
-      Objet : Awesome report.
+        ________________________________
+        De : Bob <bob@example.com>
+        Envoyé : mercredi 15 juin 2016 07:24
+        À : robert@example.com
+        Objet : Awesome report.
 
-      Check out this report!
+        Check out this report!
       EOF
 
       expect(body_from_email(text: body)).to eq 'Hello.'
@@ -693,7 +693,7 @@ describe Griddler::Email, 'extracting email addresses' do
     email = Griddler::Email.new(
       text: 'hi',
       to: [@address_components[:email]],
-      from: @full_address
+      from: @full_address,
     )
     expected = @address_components.merge(
       full: @address_components[:email],
@@ -715,8 +715,11 @@ describe Griddler::Email, 'extracting email addresses' do
   end
 
   it 'handles new lines' do
-    email = Griddler::Email.new(text: 'hi', to: ["#{@full_address}\n"],
-                                from: "#{@full_address}\n")
+    email = Griddler::Email.new(
+      text: 'hi',
+      to: ["#{@full_address}\n"],
+      from: "#{@full_address}\n",
+    )
     expected = @address_components.merge(full: "#{@full_address}\n")
     expect(email.to).to eq [expected]
     expect(email.from).to eq expected
@@ -726,11 +729,12 @@ describe Griddler::Email, 'extracting email addresses' do
     email = Griddler::Email.new(
       text: 'hi',
       to: ["<#{@address_components[:email]}>"],
-      from: "<#{@address_components[:email]}>"
+      from: "<#{@address_components[:email]}>",
     )
     expected = @address_components.merge(
       full: "<#{@address_components[:email]}>",
-      name: nil)
+      name: nil,
+    )
     expect(email.to).to eq [expected]
     expect(email.from).to eq expected
   end

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -158,7 +158,8 @@ describe Griddler::Email, 'body formatting' do
   end
 
   it 'handles french format: "Le [date], [soandso] <email@example.com> a écrit :"' do
-    body = <<-EOF.strip_heredoc
+    I18n.with_locale(:fr) do
+      body = <<-EOF.strip_heredoc
       Hello.
 
       Le 11 mars 2016, at 18:00, Tristan <email@example.com> a écrit :
@@ -168,13 +169,15 @@ describe Griddler::Email, 'body formatting' do
       >
       > Thanks, Tristan
       >
-    EOF
+      EOF
 
-    expect(body_from_email(text: body)).to eq 'Hello.'
+      expect(body_from_email(text: body)).to eq 'Hello.'
+    end
   end
 
   it 'handles LONG french format: "Le [date], [soandso] <email@example.com> a écrit :"' do
-    body = <<-EOF.strip_heredoc
+    I18n.with_locale(:fr) do
+      body = <<-EOF.strip_heredoc
       Hello.
 
       Le 11 mars 2016, at 18:00, Tristan With A Really Really Long Name <
@@ -186,13 +189,15 @@ describe Griddler::Email, 'body formatting' do
       >
       > Thanks, Tristan
       >
-    EOF
+      EOF
 
-    expect(body_from_email(text: body)).to eq 'Hello.'
+      expect(body_from_email(text: body)).to eq 'Hello.'
+    end
   end
 
   it 'handles spanish format: "El [date], [soandso] <email@example.com> escribió:"' do
-    body = <<-EOF.strip_heredoc
+    I18n.with_locale(:es) do
+      body = <<-EOF.strip_heredoc
       Hello.
 
       El 11/03/2016 11:34, Pedro Pérez <email@example.com> escribió:
@@ -202,13 +207,15 @@ describe Griddler::Email, 'body formatting' do
       >
       > Thanks, Pedro
       >
-    EOF
+      EOF
 
-    expect(body_from_email(text: body)).to eq 'Hello.'
+      expect(body_from_email(text: body)).to eq 'Hello.'
+    end
   end
 
   it 'handles LONG spanish format: "El [date], [soandso] <email@example.com> escribió:"' do
-    body = <<-EOF.strip_heredoc
+    I18n.with_locale(:es) do
+      body = <<-EOF.strip_heredoc
       Hello.
 
       El 11/03/2016 11:34, Pedro Pérez <
@@ -219,9 +226,10 @@ describe Griddler::Email, 'body formatting' do
       >
       > Thanks, Pedro
       >
-    EOF
+      EOF
 
-    expect(body_from_email(text: body)).to eq 'Hello.'
+      expect(body_from_email(text: body)).to eq 'Hello.'
+    end
   end
 
   it 'handles "From: email@email.com" format' do
@@ -253,7 +261,8 @@ describe Griddler::Email, 'body formatting' do
   end
 
   it 'handles "De : Firstname <email@email.com>" format (french Outlook)' do
-    body = <<-EOF
+    I18n.with_locale(:fr) do
+      body = <<-EOF
       Hello.
 
       ________________________________
@@ -263,9 +272,10 @@ describe Griddler::Email, 'body formatting' do
       Objet : Awesome report.
 
       Check out this report!
-    EOF
+      EOF
 
-    expect(body_from_email(text: body)).to eq 'Hello.'
+      expect(body_from_email(text: body)).to eq 'Hello.'
+    end
   end
 
   it 'handles "-----Original Message-----" format' do
@@ -696,17 +706,17 @@ describe Griddler::Email, 'extracting email addresses' do
 
   it 'returns the BCC email' do
     email = Griddler::Email.new(
-        text: 'hi',
-        to: [@address_components[:email]],
-        from: @full_address,
-        bcc: [@full_bcc_address],
+      text: 'hi',
+      to: [@address_components[:email]],
+      from: @full_address,
+      bcc: [@full_bcc_address],
     )
     expect(email.bcc).to eq [@bcc_address_components]
   end
 
   it 'handles new lines' do
     email = Griddler::Email.new(text: 'hi', to: ["#{@full_address}\n"],
-      from: "#{@full_address}\n")
+                                from: "#{@full_address}\n")
     expected = @address_components.merge(full: "#{@full_address}\n")
     expect(email.to).to eq [expected]
     expect(email.from).to eq expected

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../dummy/config/environment", __FILE__)
 require 'rspec/rails'
 require 'helpers/fixtures_helper'
+require 'pry'
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ ENV["RAILS_ENV"] ||= 'test'
 require File.expand_path("../dummy/config/environment", __FILE__)
 require 'rspec/rails'
 require 'helpers/fixtures_helper'
-require 'pry'
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true


### PR DESCRIPTION
This PR is in response to issue https://github.com/thoughtbot/griddler/issues/286.

**What it does:**

* Extracts regexes from `EmailParser` and places them into their respective locale files
* Adds locale files for english, french and spanish 
* Updates specs to assert using the correct locale
* Adds I18n as a gem dependency

**Why:**

* These changes will prevent the need to continually add one off regexes to `EmailParser.regex_split_points`. Instead, support for other languages can be added through typical I18n via separate yml files. 
* This will make it easier to identify what formats are missing and for what languages

**Questions:**

* Do we need to identify the `Content-Language` from the received email in order to set the `I18n.locale`? Or will this just work?
