### PR TITLE
Spec to test Rails 5.1 and convert to request spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - "RAILS_BRANCH=4-1-stable"
   - "RAILS_BRANCH=4-2-stable"
   - "RAILS_BRANCH=5-0-stable"
+  - "RAILS_BRANCH=5-1-stable"
   - "RAILS_BRANCH=master"
 branches:
   only:

--- a/spec/controllers/griddler/emails_controller_spec.rb
+++ b/spec/controllers/griddler/emails_controller_spec.rb
@@ -9,7 +9,7 @@ describe Griddler::EmailsController, :type => :controller do
 
   describe 'POST create', type: :controller do
     it 'is successful' do
-      post :create, email_params
+      post :create, params: email_params
 
       expect(response).to be_success
     end
@@ -20,7 +20,7 @@ describe Griddler::EmailsController, :type => :controller do
         with(hash_including(to: ['tb@example.com'])).
         and_return(email)
 
-      post :create, { to: 'tb@example.com' }
+      post :create, params: { to: 'tb@example.com' }
     end
 
     it 'calls process on the custom processor class' do
@@ -28,7 +28,7 @@ describe Griddler::EmailsController, :type => :controller do
       expect(my_handler).to receive(:new).and_return(my_handler)
       allow(Griddler.configuration).to receive_messages(processor_class: my_handler)
 
-      post :create, email_params
+      post :create, params: email_params
     end
 
     it 'calls the custom processor method on the processor class' do
@@ -38,7 +38,7 @@ describe Griddler::EmailsController, :type => :controller do
       expect(EmailProcessor).to receive(:new).and_return(fake_processor)
       expect(fake_processor).to receive(:perform)
 
-      post :create, email_params
+      post :create, params: email_params
     end
   end
 

--- a/spec/controllers/griddler/emails_controller_spec.rb
+++ b/spec/controllers/griddler/emails_controller_spec.rb
@@ -1,15 +1,17 @@
 require 'spec_helper'
 
-describe Griddler::EmailsController, :type => :controller do
+RSpec.describe "sending data", :type => :request do
   before(:each) do
     fake_adapter = double(normalize_params: normalized_params)
     Griddler.adapter_registry.register(:one_that_works, fake_adapter)
     Griddler.configuration.email_service = :one_that_works
   end
 
-  describe 'POST create', type: :controller do
+  let(:path) { "/email_processor" }
+
+  describe 'POST create' do
     it 'is successful' do
-      post :create, params: email_params
+      post path, params: email_params
 
       expect(response).to be_success
     end
@@ -20,7 +22,7 @@ describe Griddler::EmailsController, :type => :controller do
         with(hash_including(to: ['tb@example.com'])).
         and_return(email)
 
-      post :create, params: { to: 'tb@example.com' }
+      post path, params: { to: 'tb@example.com' }
     end
 
     it 'calls process on the custom processor class' do
@@ -28,7 +30,7 @@ describe Griddler::EmailsController, :type => :controller do
       expect(my_handler).to receive(:new).and_return(my_handler)
       allow(Griddler.configuration).to receive_messages(processor_class: my_handler)
 
-      post :create, params: email_params
+      post path, params: email_params
     end
 
     it 'calls the custom processor method on the processor class' do
@@ -38,7 +40,7 @@ describe Griddler::EmailsController, :type => :controller do
       expect(EmailProcessor).to receive(:new).and_return(fake_processor)
       expect(fake_processor).to receive(:perform)
 
-      post :create, params: email_params
+      post path, params: email_params
     end
   end
 

--- a/spec/requests/griddler/emails_request_spec.rb
+++ b/spec/requests/griddler/emails_request_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-RSpec.describe "Receiving Email", :type => :request do
+RSpec.describe 'Receiving Email', type: :request do
   before(:each) do
     fake_adapter = double(normalize_params: normalized_params)
     Griddler.adapter_registry.register(:one_that_works, fake_adapter)
     Griddler.configuration.email_service = :one_that_works
   end
 
-  let(:path) { "/email_processor" }
+  let(:path) { '/email_processor' }
 
   describe 'POST create' do
     it 'is successful' do

--- a/spec/requests/griddler/emails_request_spec.rb
+++ b/spec/requests/griddler/emails_request_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe "sending data", :type => :request do
+RSpec.describe "Receiving Email", :type => :request do
   before(:each) do
     fake_adapter = double(normalize_params: normalized_params)
     Griddler.adapter_registry.register(:one_that_works, fake_adapter)

--- a/spec/requests/griddler/emails_request_spec.rb
+++ b/spec/requests/griddler/emails_request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Receiving Email", :type => :request do
     it 'is successful' do
       post path, params: email_params
 
-      expect(response).to be_success
+      expect(response).to be_successful
     end
 
     it 'creates a new Griddler::Email with the given params' do


### PR DESCRIPTION
1. Allow to test Rails 5.1, which in turn need to have spec changed to use `params` to pass parameters.
2. Convert controller spec to request spec.
3. Convert deprecated call to `success?` to `successful?`