### PR TITLE
Skip CSRF check in controller

### DIFF
--- a/app/controllers/griddler/emails_controller.rb
+++ b/app/controllers/griddler/emails_controller.rb
@@ -1,4 +1,6 @@
 class Griddler::EmailsController < ActionController::Base
+  skip_before_action :verify_authenticity_token
+
   def create
     normalized_params.each do |p|
       process_email email_class.new(p)


### PR DESCRIPTION
This simply skips the CSRF check in the emails controller to address issue #297. Rails 5.2.0 now includes the CSRF before action by default so this change is necessary for the gem to work out of the box.