### PR TITLE
ArgumentError with verify_authenticity_token on Rails API

### DIFF
--- a/app/controllers/griddler/emails_controller.rb
+++ b/app/controllers/griddler/emails_controller.rb
@@ -1,5 +1,5 @@
 class Griddler::EmailsController < ActionController::Base
-  skip_before_action :verify_authenticity_token
+  skip_before_action :verify_authenticity_token, raise: false
 
   def create
     normalized_params.each do |p|


### PR DESCRIPTION
I got this error when launching `resque:work` with Rails 5.1.6 API only, and because CSRF token is disabled by default in API mode, the new `skip_before_action` doesn't work.

```
ArgumentError: Before process_action callback :verify_authenticity_token has not been defined
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/callbacks.rb:712:in `block (2 levels) in skip_callback'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/callbacks.rb:708:in `each'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/callbacks.rb:708:in `block in skip_callback'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/callbacks.rb:622:in `block in __update_callbacks'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/callbacks.rb:620:in `reverse_each'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/callbacks.rb:620:in `__update_callbacks'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/callbacks.rb:707:in `skip_callback'
worker_1       | /usr/local/bundle/gems/actionpack-5.1.6/lib/abstract_controller/callbacks.rb:181:in `block (3 levels) in <module:ClassMethods>'
worker_1       | /usr/local/bundle/gems/actionpack-5.1.6/lib/abstract_controller/callbacks.rb:74:in `block in _insert_callbacks'
worker_1       | /usr/local/bundle/gems/actionpack-5.1.6/lib/abstract_controller/callbacks.rb:73:in `each'
worker_1       | /usr/local/bundle/gems/actionpack-5.1.6/lib/abstract_controller/callbacks.rb:73:in `_insert_callbacks'
worker_1       | /usr/local/bundle/gems/actionpack-5.1.6/lib/abstract_controller/callbacks.rb:180:in `block (2 levels) in <module:ClassMethods>'
worker_1       | /usr/local/bundle/gems/griddler-1.5.0/app/controllers/griddler/emails_controller.rb:2:in `<class:EmailsController>'
worker_1       | /usr/local/bundle/gems/griddler-1.5.0/app/controllers/griddler/emails_controller.rb:1:in `<main>'
worker_1       | /usr/local/bundle/gems/bootsnap-1.3.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:100:in `load'
worker_1       | /usr/local/bundle/gems/bootsnap-1.3.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:100:in `load'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:477:in `block in load_file'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:662:in `new_constants_in'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:476:in `load_file'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:374:in `block in require_or_load'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:36:in `block in load_interlock'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/dependencies/interlock.rb:12:in `block in loading'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/concurrency/share_lock.rb:149:in `exclusive'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/dependencies/interlock.rb:11:in `loading'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:36:in `load_interlock'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:357:in `require_or_load'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:335:in `depend_on'
worker_1       | /usr/local/bundle/gems/bootsnap-1.3.0/lib/bootsnap/load_path_cache/core_ext/active_support.rb:59:in `depend_on'
worker_1       | /usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:251:in `require_dependency'
worker_1       | /usr/local/bundle/gems/railties-5.1.6/lib/rails/engine.rb:476:in `block (2 levels) in eager_load!'
worker_1       | /usr/local/bundle/gems/railties-5.1.6/lib/rails/engine.rb:475:in `each'
worker_1       | /usr/local/bundle/gems/railties-5.1.6/lib/rails/engine.rb:475:in `block in eager_load!'
worker_1       | /usr/local/bundle/gems/railties-5.1.6/lib/rails/engine.rb:473:in `each'
worker_1       | /usr/local/bundle/gems/railties-5.1.6/lib/rails/engine.rb:473:in `eager_load!'
worker_1       | /usr/local/bundle/gems/railties-5.1.6/lib/rails/engine.rb:354:in `eager_load!'
worker_1       | /usr/local/bundle/gems/resque-1.27.4/lib/resque/tasks.rb:45:in `each'
worker_1       | /usr/local/bundle/gems/resque-1.27.4/lib/resque/tasks.rb:45:in `block (2 levels) in <main>'
worker_1       | /usr/local/bundle/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
```