### PR TITLE
Explicitly require Rails 4 or greater

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 if ENV["RAILS_BRANCH"]
   gem "rails", github: "rails/rails", branch: ENV["RAILS_BRANCH"]
 else
-  gem "rails", "~> 4.0.0"
+  gem "rails", ">= 4.0.0"
 end

--- a/griddler.gemspec
+++ b/griddler.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,lib}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
   s.require_paths = %w{app lib}
 
-  s.add_dependency 'rails', '>= 3.2.0'
+  s.add_dependency 'rails', '>= 4.0.0'
   s.add_dependency 'htmlentities'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'sqlite3'


### PR DESCRIPTION
I added Griddler to a Rails 3.2 app, it bundled but raised on runtime: 

```
griddler-1.5.2/app/controllers/griddler/emails_controller.rb:2:in `<class:EmailsController>': undefined method `skip_before_action' for Griddler::EmailsController:Class (NoMethodError)`
```

This happens because the skip_before_action API is introduced only in Rails 4.

Assuming there's no intention in support the 3.2 version, explicitly require Rails 4 so Bundler can complain in buidl time.
