### PR TITLE
Static attributes will be removed in FactoryBot 5.0 - Updating the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,11 @@ with the following sample factory:
 ```ruby
 factory :email, class: OpenStruct do
   # Assumes Griddler.configure.to is :hash (default)
-  to [{ full: 'to_user@email.com', email: 'to_user@email.com', token: 'to_user', host: 'email.com', name: nil }]
-  from({ token: 'from_user', host: 'email.com', email: 'from_email@email.com', full: 'From User <from_user@email.com>', name: 'From User' })
-  subject 'email subject'
-  body 'Hello!'
-  attachments {[]}
+  to { [{ full: 'to_user@email.com', email: 'to_user@email.com', token: 'to_user', host: 'email.com', name: nil }] }
+  from { { token: 'from_user', host: 'email.com', email: 'from_email@email.com', full: 'From User <from_user@email.com>', name: 'From User' } }
+  subject { 'email subject' }
+  body { 'Hello!' }
+  attachments { '0' }
 
   trait :with_attachment do
     attachments {[


### PR DESCRIPTION
FactoryBot threw a deprecation warning when I copied the example from the
readme:

```
  DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic
  attributes instead by wrapping the attribute value in a block:

  to { [{:full=>"to_user@email.com", :email=>"to_user@email.com", :token=>"to_user", :host=>"email.com", :name=>nil}] }
```

This updated the readme to use dynamic attributes.

Also: Sorry for not opening an issue first, I had already written the copy change in my code so it seemed easier :)