### PR TITLE
Fix ActionController::Parameters headers parsing

### DIFF
--- a/lib/griddler/email.rb
+++ b/lib/griddler/email.rb
@@ -109,6 +109,8 @@ module Griddler
         deep_clean_invalid_utf8_bytes(params[:headers])
       elsif params[:headers].is_a?(Array)
         deep_clean_invalid_utf8_bytes(params[:headers])
+      elsif params[:headers].is_a?(ActionController::Parameters)
+        deep_clean_invalid_utf8_bytes(params[:headers].to_unsafe_hash)
       else
         EmailParser.extract_headers(clean_invalid_utf8_bytes(params[:headers]))
       end

--- a/spec/griddler/email_spec.rb
+++ b/spec/griddler/email_spec.rb
@@ -574,6 +574,17 @@ describe Griddler::Email, 'extracting email headers' do
     expect(headers[header_name]).to eq header_value
   end
 
+  it 'coerces ActionController::Parameters to a Hash' do
+    headers_hash = {
+      'X-Mailer' => 'Airmail (271)',
+      'Mime-Version' => '1.0',
+    }
+    header = ActionController::Parameters.new(headers_hash)
+    headers = header_from_email(header)
+    expect(headers).to be_a(Hash)
+    expect(headers).to eq(headers_hash)
+  end
+
   it 'handles a hash being submitted' do
     header = {
       "X-Mailer" => "Airmail (271)",


### PR DESCRIPTION
ActionController::Parameters is not a Hash anymore and doesn't behave
like one, since Rails 5.

We need to coerce it to a Hash, since the rest of our codebase expects
it to be a hash and all strings to be properly.