### PR TITLE
remove route helper

### DIFF
--- a/griddler.gemspec
+++ b/griddler.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rails', '>= 3.2.0'
   s.add_dependency 'htmlentities'
+  s.add_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails'
-  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'pry'
   # jquery-rails is used by the dummy Rails application
   s.add_development_dependency 'jquery-rails'

--- a/lib/griddler/route_extensions.rb
+++ b/lib/griddler/route_extensions.rb
@@ -1,7 +1,7 @@
 module Griddler
   module RouteExtensions
     def mount_griddler(path='/email_processor')
-      post path => 'griddler/emails#create', as: :email_processor
+      post path => 'griddler/emails#create'
     end
   end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -1,5 +1,12 @@
 Dummy::Application.routes.draw do
-  mount_griddler
+  scope 'v1' do
+    mount_griddler
+  end
+
+  scope 'v2' do
+    mount_griddler
+  end
+
   # The priority is based upon order of creation:
   # first created -> highest priority.
 

--- a/spec/requests/griddler/emails_request_spec.rb
+++ b/spec/requests/griddler/emails_request_spec.rb
@@ -7,13 +7,23 @@ RSpec.describe 'Receiving Email', type: :request do
     Griddler.configuration.email_service = :one_that_works
   end
 
-  let(:path) { '/email_processor' }
+  let(:path) { '/v1/email_processor' }
 
   describe 'POST create' do
     it 'is successful' do
       post path, params: email_params
 
       expect(response).to be_successful
+    end
+
+    context 'with another API version' do
+      let(:path) { '/v2/email_processor' }
+
+      it 'is also successful' do
+        post path, params: email_params
+
+        expect(response).to be_successful
+      end
     end
 
     it 'creates a new Griddler::Email with the given params' do


### PR DESCRIPTION
The route helper path is avoiding multiple definitions of `mount_griddler` in routes.rb

I made a test with multiple API versions and griddler and I removed the route helper path.

UPDATE: It was removed at 4a1fb50 but not completely